### PR TITLE
Adding counter for repeating devices on agents page and detail page

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -33,6 +33,7 @@
 - The agent status page shows more detailed information on temperature and usage.
 - JQuery updated to v3.6.0.
 - Print database connection error in UI theme.
+- Agents overview page and agent detail page now show counter for repeating devices
 
 # v0.11.0 -> v0.12.0
 

--- a/src/agents.php
+++ b/src/agents.php
@@ -63,6 +63,14 @@ if (isset($_GET['id'])) {
     UI::printError("ERROR", "No access to this agent!");
   }
   else {
+        // uniq devices lines and prepend with count
+        $tmp_devices_tuple = array_count_values(explode("\n", $agent->getDevices()));
+        $devices_tuple = array();
+        foreach ($tmp_devices_tuple as $key => $value) {
+          $devices_tuple[] = str_replace("*", "&nbsp;&nbsp'", sprintf("%'*2d&times' ", $value) . $key);
+        }
+        $agent->setDevices(implode("\n", $devices_tuple));
+
     UI::add('agent', $agent);
     UI::add('users', Factory::getUserFactory()->filter([]));
     UI::add('pageTitle', "Agent details for " . $agent->getAgentName());
@@ -149,7 +157,13 @@ else {
     $jF = new JoinFilter(Factory::getAccessGroupAgentFactory(), AccessGroup::ACCESS_GROUP_ID, AccessGroupAgent::ACCESS_GROUP_ID);
     $joined = Factory::getAccessGroupFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
     $accessGroupAgents->addValue($agent->getId(), $joined[Factory::getAccessGroupFactory()->getModelName()]);
-    $agent->setDevices(Util::compressDevices(explode("\n", $agent->getDevices())));
+    // uniq devices lines and prepend with count
+    $tmp_devices_tuple = array_count_values(explode("\n", $agent->getDevices()));
+    $devices_tuple = array();
+    foreach ($tmp_devices_tuple as $key => $value) {
+      $devices_tuple[] = str_replace("*", "&nbsp;&nbsp'", sprintf("%'*2d&times' ", $value) . $key);
+    }
+    $agent->setDevices(implode("\n", $devices_tuple));
   }
   
   UI::add('accessGroupAgents', $accessGroupAgents);

--- a/src/templates/agents/index.template.html
+++ b/src/templates/agents/index.template.html
@@ -50,9 +50,7 @@
               {{ENDIF}}
             </td>
             <td>
-              {{FOREACH device;[[agent.getDevices()]]}}
-                [[Util::shortenstring([[device]], 20)]]<br>
-              {{ENDFOREACH}}
+              [[str_replace("\n","<br>",[[agent.getDevices()]])]]
             </td>
             <td>
               {{IF [[agent.getCpuOnly()]] == 0}}


### PR DESCRIPTION
Small change to the agent overview page and agent detail page. If a device is repeating (for example you have 4 Nvidia 1080's in a agent, they will now be displayed as 4x Nvidia 1080 instead of 4 lines.

Before:
![agent_count_2](https://user-images.githubusercontent.com/4386076/132949957-457d4c41-e3d2-4105-bca0-f84e5ddf8962.png)

After:
![agent_count_1](https://user-images.githubusercontent.com/4386076/132949968-ebd9da33-b155-4c6e-899c-5f0f66272c96.png)
