### PR TITLE
Allow Agents to be unassigned from their task.

### DIFF
--- a/src/inc/utils/AgentUtils.class.php
+++ b/src/inc/utils/AgentUtils.class.php
@@ -372,7 +372,7 @@ class AgentUtils {
   public static function assign($agentId, $taskId, $user) {
     $agent = AgentUtils::getAgent($agentId, $user);
 
-    if ($taskId == 0) { // unassign
+    if ($taskId == 0 || empty($taskId)) { // unassign
       $qF = new QueryFilter(Agent::AGENT_ID, $agent->getId(), "=");
       Factory::getAssignmentFactory()->massDeletion([Factory::FILTER => $qF]);
       if (isset($_GET['task'])) {


### PR DESCRIPTION
A bug causes $taskId to be empty / unset instead of 0 causing it to error saying no task exists.
This change fixes that bug.