### PR TITLE
Enhancement: increase size of value column for agentstats

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -21,7 +21,7 @@
 - Adjusted handling to be able to deal with changed mode 22000 output.
 - Fixed pagination of hashes on cracks page.
 - Time of Zaps inserted is now saved.
-- Fixed unable to unassign agent from the task detail screen
+- Fixed unable to unassign agent from the task detail screen.
 
 ## Enhancements
 
@@ -34,7 +34,8 @@
 - The agent status page shows more detailed information on temperature and usage.
 - JQuery updated to v3.6.0.
 - Print database connection error in UI theme.
-- Agents overview page and agent detail page now show counter for repeating devices
+- Agents overview page and agent detail page now show counter for repeating devices.
+- Increase size of database column for storing agentstats.
 
 # v0.11.0 -> v0.12.0
 

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -71,7 +71,7 @@ CREATE TABLE `AgentStat` (
   `agentId`     INT(11)     NOT NULL,
   `statType`    INT(11)     NOT NULL,
   `time`        BIGINT      NOT NULL,
-  `value`       VARCHAR(64) NOT NULL
+  `value`       VARCHAR(128) NOT NULL
 ) ENGINE = InnoDB;
 
 CREATE TABLE `AgentZap` (

--- a/src/install/updates/update_v0.12.x_v0.x.x.php
+++ b/src/install/updates/update_v0.12.x_v0.x.x.php
@@ -125,3 +125,7 @@ if (!isset($PRESENT["v0.12.x_agentBinariesUpdateTrack"])) {
   $EXECUTED["v0.12.x_agentBinariesUpdateTrack"] = true;
 }
 
+if (!isset($PRESENT["v0.12.x_agentStatValue"])) {
+  Factory::getFileFactory()->getDB()->query("ALTER TABLE `AgentStat` MODIFY `value` VARCHAR(128);");
+  $EXECUTED["v0.12.x_fileLineCount"] = true;
+}


### PR DESCRIPTION
In some cases the value size is not big enough to store the agents stats, resulting in an internal server error. This fixes that issue.

```
# php update.php

mysql> DESCRIBE AgentStat;
+-------------+--------------+------+-----+---------+----------------+
| Field       | Type         | Null | Key | Default | Extra          |
+-------------+--------------+------+-----+---------+----------------+
| agentStatId | int(11)      | NO   | PRI | NULL    | auto_increment |
| agentId     | int(11)      | NO   | MUL | NULL    |                |
| statType    | int(11)      | NO   |     | NULL    |                |
| time        | bigint(20)   | NO   |     | NULL    |                |
| value       | varchar(128) | YES  |     | NULL    |                |
+-------------+--------------+------+-----+---------+----------------+
5 rows in set (0.00 sec)
```