### PR TITLE
Speed graph fixed with different status timer

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -22,6 +22,7 @@
 - Fixed pagination of hashes on cracks page.
 - Time of Zaps inserted is now saved.
 - Fixed unable to unassign agent from the task detail screen
+- Fixed speed graph incorrect when status timer is different from servers default.
 
 ## Enhancements
 

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -296,7 +296,7 @@ if (isset($_GET['id'])) {
   UI::add('pageTitle', "Task details for " . $task->getTaskName());
   
   // load graph data
-  $data = Util::getSpeedDataSet($task->getId());
+  $data = Util::getSpeedDataSet($task->getId(), 50, 0, $task->getStatusTimer());
   if (sizeof($data) > 0) {
     $xlabels = [];
     $rawData = [];


### PR DESCRIPTION
To reproduce this bug, create a new task, set the status timer of the task to something different then the servers default. In my example: 30s (server default is 5s). Let the task run for a couple of status updates intervals. You'll see that the graph of the speed will contain drops and is not a consistent line. This is just because the graph is created with the servers default status timer in mind and creates data-points for status updates that are simply not there. This fixes that issue and makes sure the graph will be displayed correctly: a stable line in my example.

Before:
![graph_before](https://user-images.githubusercontent.com/4386076/155516047-0c56b198-65d7-4aa6-ac17-97a07de54dca.PNG)

After:
![graph_after](https://user-images.githubusercontent.com/4386076/155516046-af92a76b-8368-406d-a3dd-f1d1343c90c1.PNG)

