### PR TITLE
Agent details hide/show button

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -35,6 +35,7 @@
 - JQuery updated to v3.6.0.
 - Print database connection error in UI theme.
 - Agents overview page and agent detail page now show counter for repeating devices
+- Agent detail page now has a hide/show button for the config parameters.
 
 # v0.11.0 -> v0.12.0
 

--- a/src/templates/agents/detail.template.html
+++ b/src/templates/agents/detail.template.html
@@ -41,7 +41,7 @@
       </tr>
     </table>
 
-    <a class="btn btn-primary accordion-toggle" role="button" onclick="window.location.reload();expansionCheck('#showAgentDetails[[agent.getId()]]')" href="#showAgentDetails[[agent.getId()]]" data-toggle="collapse">Show/Hide details</a>
+    <a class="btn btn-primary accordion-toggle my-1" role="button" onclick="window.location.reload();expansionCheck('#showAgentDetails[[agent.getId()]]')" href="#showAgentDetails[[agent.getId()]]" data-toggle="collapse">Show/Hide details</a>
 
     <table class="table table-bordered accordion-body collapse" id="showAgentDetails[[agent.getId()]]" aria-expanded="true">
       <tr>

--- a/src/templates/agents/detail.template.html
+++ b/src/templates/agents/detail.template.html
@@ -8,11 +8,6 @@
       <tr>
         <td>Agent ID:</td>
         <td>[[agent.getId()]]</td>
-        <td>
-          <form style ='float: right; padding-right: 5px;'>
-            <a class="btn btn-primary accordion-toggle" role="button" onclick="window.location.reload();expansionCheck('#showAgentDetails[[agent.getId()]]')" href="#showAgentDetails[[agent.getId()]]" data-toggle="collapse">Show/Hide details</a>
-          </form>
-        </td>
       </tr>
 
       <tr>
@@ -45,6 +40,8 @@
         </td>
       </tr>
     </table>
+
+    <a class="btn btn-primary accordion-toggle" role="button" onclick="window.location.reload();expansionCheck('#showAgentDetails[[agent.getId()]]')" href="#showAgentDetails[[agent.getId()]]" data-toggle="collapse">Show/Hide details</a>
 
     <table class="table table-bordered accordion-body collapse" id="showAgentDetails[[agent.getId()]]" aria-expanded="true">
       <tr>

--- a/src/templates/agents/detail.template.html
+++ b/src/templates/agents/detail.template.html
@@ -6,38 +6,17 @@
   <div class="table-responsive">
     <table class="table table-bordered">
       <tr>
-        <td>Property</td>
-        <td>Value</td>
-      </tr>
-      <tr>
-        <td>ID</td>
+        <td>Agent ID:</td>
         <td>[[agent.getId()]]</td>
-      </tr>
-      <tr>
-        <td>Owner</td>
         <td>
-          {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_AGENT_ACCESS]])]]}}
-            <form class='form-inline' action="agents.php?id=[[agent.getId()]]" method="post">
-              <input type='hidden' name='action' value='[[$DAgentAction::SET_OWNER]]'>
-              <input type='hidden' name='agentId' value='[[agent.getId()]]'>
-              <input type="hidden" name="csrf" value="[[csrf]]">
-              <div class="form-group">
-                <select class='form-control' name='owner' title="owner">
-                  <option value="">---</option>
-                  {{FOREACH user;[[users]]}}
-                    <option value='[[user.getId()]]' {{IF [[user.getId()]] == [[agent.getUserId()]]}} selected{{ENDIF}}>[[htmlentities([[user.getUsername()]], ENT_QUOTES, "UTF-8")]]</option>
-                  {{ENDFOREACH}}
-                </select>
-              </div>&nbsp;&nbsp;
-              <button type="submit" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark {{ELSE}}btn-light{{ENDIF}}" data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
-            </form>
-          {{ELSE}}
-            [[htmlentities([[Util::getUsernameById([[agent.getUserId()]])]], ENT_QUOTES, "UTF-8")]]
-          {{ENDIF}}
+          <form style ='float: right; padding-right: 5px;'>
+            <a class="btn btn-primary accordion-toggle" role="button" onclick="window.location.reload();expansionCheck('#showAgentDetails[[agent.getId()]]')" href="#showAgentDetails[[agent.getId()]]" data-toggle="collapse">Show/Hide details</a>
+          </form>
         </td>
       </tr>
+
       <tr>
-        <td>Activity:</td>
+        <td>Active:</td>
         <td>
           {{IF [[agent.getUserId()]] == [[login.getUserId()]] || [[accessControl.hasPermission([[$DAccessControl::MANAGE_AGENT_ACCESS]])]]}}
             <form id="active[[agent.getId()]]" action="agents.php?id=[[agent.getId()]]" method="post">
@@ -48,6 +27,46 @@
             </form>
           {{ELSE}}
             <input type="checkbox" {{IF [[agent.getIsActive()]] == 1}} checked{{ENDIF}} disabled title="Is Active">
+          {{ENDIF}}
+        </td>
+      </tr>
+
+      <tr>
+        <td>Last activity:</td>
+        <td>
+          Action: [[agent.getLastAct()]]<br>
+          Time: [[date([[config.getVal(DConfig::TIME_FORMAT)]], [[agent.getLastTime()]])]]<br>
+          IP:
+          {{IF [[config.getVal([[$DConfig::HIDE_IP_INFO]])]] == 0}}
+          <code>[[agent.getLastIp()]]</code>
+          {{ELSE}}
+          <code>Hidden</code>
+          {{ENDIF}}
+        </td>
+      </tr>
+    </table>
+
+    <table class="table table-bordered accordion-body collapse" id="showAgentDetails[[agent.getId()]]" aria-expanded="true">
+      <tr>
+        <td>Owner</td>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_AGENT_ACCESS]])]]}}
+          <form class='form-inline' action="agents.php?id=[[agent.getId()]]" method="post">
+            <input type='hidden' name='action' value='[[$DAgentAction::SET_OWNER]]'>
+            <input type='hidden' name='agentId' value='[[agent.getId()]]'>
+            <input type="hidden" name="csrf" value="[[csrf]]">
+            <div class="form-group">
+              <select class='form-control' name='owner' title="owner">
+                <option value="">---</option>
+                {{FOREACH user;[[users]]}}
+                <option value='[[user.getId()]]' {{IF [[user.getId()]] == [[agent.getUserId()]]}} selected{{ENDIF}}>[[htmlentities([[user.getUsername()]], ENT_QUOTES, "UTF-8")]]</option>
+                {{ENDFOREACH}}
+              </select>
+            </div>&nbsp;&nbsp;
+            <button type="submit" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark {{ELSE}}btn-light{{ENDIF}}" data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+          </form>
+          {{ELSE}}
+          [[htmlentities([[Util::getUsernameById([[agent.getUserId()]])]], ENT_QUOTES, "UTF-8")]]
           {{ENDIF}}
         </td>
       </tr>
@@ -200,19 +219,6 @@
       </tr>
       {{ENDIF}}
       <tr>
-        <td>Last activity:</td>
-        <td>
-          Action: [[agent.getLastAct()]]<br>
-          Time: [[date([[config.getVal(DConfig::TIME_FORMAT)]], [[agent.getLastTime()]])]]<br>
-          IP:
-          {{IF [[config.getVal([[$DConfig::HIDE_IP_INFO]])]] == 0}}
-            <code>[[agent.getLastIp()]]</code>
-          {{ELSE}}
-            <code>Hidden</code>
-          {{ENDIF}}
-        </td>
-      </tr>
-      <tr>
         <td>Time spent cracking:</td>
         <td>[[Util::sectotime([[timeSpent]])]]</td>
       </tr>
@@ -343,4 +349,11 @@
     </table>
   </div>
 </div>
+
+<script type="text/javascript">
+  $( document ).ready(function() {
+    checkOnLoading("#showAgentDetails[[agent.getId()]]");
+  });
+</script>
+
 {%TEMPLATE->struct/foot%}


### PR DESCRIPTION
This pull requests adds a hide/show button on the agent details page so that the graph and other information is easier to access.

Before:
![agent_before](https://user-images.githubusercontent.com/4386076/155519626-b890a934-13c0-4ba3-9a42-68485b74b496.PNG)

After:
![agent_after_1](https://user-images.githubusercontent.com/4386076/155519642-0a38f882-2e28-4782-9e0c-5634cb2de53b.PNG)

Clicking the button:
![agent_after_2](https://user-images.githubusercontent.com/4386076/155519654-a7228db1-7453-4ca1-ab90-0d1b95cc0837.PNG)

