### PR TITLE
Add support for maximum amount of agents that should work on a task.

### DIFF
--- a/ci/run.php
+++ b/ci/run.php
@@ -26,6 +26,12 @@ foreach ($dir as $entry) {
     require_once(dirname(__FILE__) . "/tests/" . $entry);
   }
 }
+$dir = scandir(dirname(__FILE__) . "/tests/integration/");
+foreach ($dir as $entry) {
+  if (strpos($entry, ".php") !== false) {
+    require_once(dirname(__FILE__) . "/tests/integration/" . $entry);
+  }
+}
 
 $TEST = true;
 

--- a/ci/tests/PretaskTest.class.php
+++ b/ci/tests/PretaskTest.class.php
@@ -249,6 +249,7 @@ class PretaskTest extends HashtopolisTest {
       "crackerTypeId" => $crackerTypeId,
       "files" => $files,
       "priority" => $priority,
+      "maxAgents" => 16,
       "accessKey" => "mykey"
     ], HashtopolisTestFramework::REQUEST_UAPI
     );

--- a/ci/tests/TaskTest.class.php
+++ b/ci/tests/TaskTest.class.php
@@ -50,6 +50,7 @@ class TaskTest extends HashtopolisTest {
       "crackerVersionId" => 0,
       "files" => [],
       "priority" => 0,
+      "maxAgents" => 0,
       "preprocessorId" => 0,
       "preprocessorCommand" => "",
       "accessKey" => "mykey"

--- a/ci/tests/integration/MaxAgentsTest.class.php
+++ b/ci/tests/integration/MaxAgentsTest.class.php
@@ -50,14 +50,14 @@ class MaxAgentsTest extends HashtopolisTest {
     // verify agent 1 is assigned to task 1
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
     if ($response["taskId"] != $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
       return;
     }
 
     // verify agent 2 is assigned to task 1
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
     if ($response["taskId"] != $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 2, instead got: %s", $task1Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 2, instead got: %s", $task1Id, implode(", ", $response)));
       return;
     }
 
@@ -87,7 +87,7 @@ class MaxAgentsTest extends HashtopolisTest {
     // verify agent 2 is NOT assigned to task 1
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
     if ($response["taskId"] == $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected no task for agent 2, instead got: %s", implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected no task for agent 2, instead got: %s", implode(", ", $response)));
       return;
     }
     // verify getting chunk by agent 2 for task 1 now fails, because the task is already saturated
@@ -96,7 +96,7 @@ class MaxAgentsTest extends HashtopolisTest {
       "taskId" => $task1Id,
       "token" => $agent2["token"]]);
     if ($response["response"] !== "ERROR" || $response["message"] != "Task already saturated by other agents, no other task available!") {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to fail, instead got: %s", implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected getChunk to fail, instead got: %s", implode(", ", $response)));
       return;
     }
 
@@ -111,7 +111,7 @@ class MaxAgentsTest extends HashtopolisTest {
     // verify agent 1 is assigned to task 1
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
     if ($response["taskId"] != $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
       return;
     }
 
@@ -130,14 +130,14 @@ class MaxAgentsTest extends HashtopolisTest {
     // verify agent 1 is assigned to task 1
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
     if ($response["taskId"] != $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
       return;
     }
 
     // verify agent 2 is assigned to task 2
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
     if ($response["taskId"] != $task2Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task2Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task2Id, implode(", ", $response)));
       return;
     }
 
@@ -147,7 +147,7 @@ class MaxAgentsTest extends HashtopolisTest {
       "taskId" => $task2Id,
       "token" => $agent2["token"]]);
     if ($response["response"] !== "SUCCESS") {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
       return;
     }
 
@@ -163,7 +163,7 @@ class MaxAgentsTest extends HashtopolisTest {
     // verify agent 2 is assigned to task 1 (since it has higher priority than task 2)
     $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
     if ($response["taskId"] != $task1Id) {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
       return;
     }
 
@@ -173,10 +173,10 @@ class MaxAgentsTest extends HashtopolisTest {
       "taskId" => $task1Id,
       "token" => $agent2["token"]]);
     if ($response["response"] !== "SUCCESS") {
-      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
+      $this->testFailed("MaxAgentsTest:testMaxAgents()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
       return;
     }
-    $this->testSuccess("TaskTest:testListTasks()");
+    $this->testSuccess("MaxAgentsTest:testMaxAgents()");
   }
 
   private function addFile($name, $type) {

--- a/ci/tests/integration/MaxAgentsTest.class.php
+++ b/ci/tests/integration/MaxAgentsTest.class.php
@@ -1,0 +1,291 @@
+<?php
+
+class MaxAgentsTest extends HashtopolisTest {
+  protected $minVersion = "0.12.0";
+  protected $maxVersion = "master";
+  protected $runType    = HashtopolisTest::RUN_FAST;
+
+  public function init($version) {
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Initializing " . $this->getTestName() . "...");
+    parent::init($version);
+  }
+
+  private function prepare() {
+    $status = true;
+    // add some files
+    $status &= $this->addFile("example.dict", 0);
+    $status &= $this->addFile("best64.rule", 1);
+
+    if (!$status) {
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Some initialization failed, most likely tests will fail!");
+    }
+  }
+
+  public function run() {
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running " . $this->getTestName() . "...");
+    $this->prepare();
+    $this->testMaxAgents();
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, $this->getTestName() . " completed");
+  }
+
+  private function testMaxAgents() {
+    $response = $this->addHashlist(["name" => "NotSecureList", "isSecure" => false]);
+    $hashlistId = $response["hashlistId"];
+
+    $agent1 = $this->createAgent("agent-1");
+    $agent2 = $this->createAgent("agent-2");
+
+    // register a single task, ready to be picked up by the agents (no limit on the amount of agents)
+    $response = $this->createTask([
+      "name" => "task-1",
+      "hashlistId" => $hashlistId,
+      "attackCmd" => "#HL# -a 0 -r best64.rule example.dict",
+      "priority" => 100,
+      "color" => "FFFFFF",
+      "crackerVersionId" => 1,
+      "files" => [1]]);
+
+    $task1Id = $response["taskId"];
+
+    // verify agent 1 is assigned to task 1
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
+    if ($response["taskId"] != $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      return;
+    }
+
+    // verify agent 2 is assigned to task 1
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
+    if ($response["taskId"] != $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 2, instead got: %s", $task1Id, implode(", ", $response)));
+      return;
+    }
+
+    // after the task is assigned, make sure to set the keyspace and benchmark parameters
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "sendKeyspace",
+      "taskId" => $task1Id,
+      "token" => $agent2["token"],
+      "keyspace" => 100]);
+
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "sendBenchmark",
+      "taskId" => $task1Id,
+      "token" => $agent2["token"],
+      "type" => "run",
+      "result" => 2000000000]);
+
+    // now set the task to only allow 1 agent to work on it
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "task",
+      "request" => "setTaskMaxAgents",
+      "accessKey" => "mykey",
+      "taskId" => $task1Id,
+      "maxAgents" => 1
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+
+    // verify agent 2 is NOT assigned to task 1
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
+    if ($response["taskId"] == $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected no task for agent 2, instead got: %s", implode(", ", $response)));
+      return;
+    }
+    // verify getting chunk by agent 2 for task 1 now fails, because the task is already saturated
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "getChunk",
+      "taskId" => $task1Id,
+      "token" => $agent2["token"]]);
+    if ($response["response"] !== "ERROR" || $response["message"] != "Task already saturated by other agents, no other task available!") {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to fail, instead got: %s", implode(", ", $response)));
+      return;
+    }
+
+    // actually unassign agent 2
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "task",
+      "request" => "taskUnassignAgent",
+      "accessKey" => "mykey",
+      "agentId" => $agent2["agentId"]
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+
+    // verify agent 1 is assigned to task 1
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
+    if ($response["taskId"] != $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      return;
+    }
+
+    // now create a second task
+    $response = $this->createTask([
+      "name" => "task-2",
+      "hashlistId" => $hashlistId,
+      "attackCmd" => "#HL# -a 0 -r best64.rule example.dict",
+      "priority" => 10,
+      "color" => "FFFFFF",
+      "crackerVersionId" => 1,
+      "files" => [2]
+    ]);
+    $task2Id = $response["taskId"];
+
+    // verify agent 1 is assigned to task 1
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent1["token"]]);
+    if ($response["taskId"] != $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      return;
+    }
+
+    // verify agent 2 is assigned to task 2
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
+    if ($response["taskId"] != $task2Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task2Id, implode(", ", $response)));
+      return;
+    }
+
+    // verify getting chunk by agent 2 for task 2 succeeds
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "getChunk",
+      "taskId" => $task2Id,
+      "token" => $agent2["token"]]);
+    if ($response["response"] !== "SUCCESS") {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
+      return;
+    }
+
+    // now set the task to allow any amount of agents to work on it
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "task",
+      "request" => "setTaskMaxAgents",
+      "accessKey" => "mykey",
+      "taskId" => $task1Id,
+      "maxAgents" => 0
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+
+    // verify agent 2 is assigned to task 1 (since it has higher priority than task 2)
+    $response = HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent2["token"]]);
+    if ($response["taskId"] != $task1Id) {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected task with id '%d' for agent 1, instead got: %s", $task1Id, implode(", ", $response)));
+      return;
+    }
+
+    // verify getting chunk by agent 2 for task 1 succeeds
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "getChunk",
+      "taskId" => $task1Id,
+      "token" => $agent2["token"]]);
+    if ($response["response"] !== "SUCCESS") {
+      $this->testFailed("TaskTest:testListTasks()", sprintf("Expected getChunk to succeed, instead got: %s", implode(", ", $response)));
+      return;
+    }
+    $this->testSuccess("TaskTest:testListTasks()");
+  }
+
+  private function addFile($name, $type) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "file",
+      "request" => "addFile",
+      "filename" => $name,
+      "fileType" => $type,
+      "source" => "inline",
+      "data" => base64_encode(file_get_contents(dirname(__FILE__) . "/../../files/$name")),
+      "accessGroupId" => 1,
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+    if ($response === false) {
+      return false;
+    }
+    else if ($response['response'] != 'OK') {
+      return false;
+    }
+    return true;
+  }
+
+  private function addHashlist($values = []) {
+    $data = base64_encode(file_get_contents(dirname(__FILE__) . "/../../files/example0.hash"));
+    $query = [
+      "section" => "hashlist",
+      "request" => "createHashlist",
+      "name" => "Test Hashlist",
+      "isSalted" => false,
+      "isSecret" => true,
+      "isHexSalt" => false,
+      "separator" => ":",
+      "format" => 0,
+      "hashtypeId" => 0,
+      "accessGroupId" => 1,
+      "data" => $data,
+      "useBrain" => false,
+      "brainFeatures" => 0,
+      "accessKey" => "mykey"
+    ];
+    foreach ($values as $key => $value) {
+      $query[$key] = $value;
+    };
+    return HashtopolisTestFramework::doRequest($query, HashtopolisTestFramework::REQUEST_UAPI);
+  }
+
+  private function createAgent($name) {
+    $voucher = "voucher-" . $name;
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "createVoucher",
+      "voucher" => $voucher,
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "register",
+      "voucher" => $voucher,
+      "name" => $name]);
+    $token = $response['token'];
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "listAgents",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    $agent = current(array_filter($response["agents"], function($a) use ($name) {
+      return $a["name"] == $name;
+    }));
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "setTrusted",
+      "accessKey" => "mykey",
+      "agentId" => $agent["agentId"],
+      "trusted" => true
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    return array("agentId" => $agent["agentId"], "token" => $token);
+  }
+
+  private function createTask($values = []) {
+    $query = [
+      "section" => "task",
+      "request" => "createTask",
+      "name" => "",
+      "hashlistId" => 0,
+      "attackCmd" => "",
+      "chunksize" => 600,
+      "statusTimer" => 5,
+      "benchmarkType" => "speed",
+      "color" => "",
+      "isCpuOnly" => false,
+      "isSmall" => false,
+      "skip" => 0,
+      "crackerVersionId" => 0,
+      "files" => [],
+      "priority" => 0,
+      "maxAgents" => 0,
+      "preprocessorId" => 0,
+      "preprocessorCommand" => "",
+      "accessKey" => "mykey"
+    ];
+    foreach ($values as $key => $value) {
+      $query[$key] = $value;
+    }
+    return HashtopolisTestFramework::doRequest($query, HashtopolisTestFramework::REQUEST_UAPI);
+  }
+
+  public function getTestName() {
+    return "Max Agents Test";
+  }
+}
+
+HashtopolisTestFramework::register(new  MaxAgentsTest());

--- a/doc/user-api/sections/pretask.tex
+++ b/doc/user-api/sections/pretask.tex
@@ -24,6 +24,30 @@
 				}
 				\end{verbatim}
 			}
+		\subsection*{\textit{setPretaskMaxAgents}}
+			Set the maximum number of assigned agents for a pretask.
+			{
+				\color{blue}
+				\begin{verbatim}
+				{
+				  "section": "pretask",
+				  "request": "setPretaskMaxAgents",
+				  "pretaskId": 1,
+				  "maxAgents": 2,
+				  "accessKey": "mykey"
+				}
+				\end{verbatim}
+			}
+			{
+				\color{OliveGreen}
+				\begin{verbatim}
+				{
+				  "section": "pretask",
+				  "request": "setPretaskMaxAgents",
+				  "response": "OK"
+				}
+				\end{verbatim}
+			}
 		\subsection*{\textit{setPretaskName}}
 			Rename a preconfigured task.
 			{
@@ -168,7 +192,7 @@
 				\end{verbatim}
 			}
 		\subsection*{\textit{createPretask}}
-			Create a new preconfigured task
+			Create a new preconfigured task.
 			{
 				\color{blue}
 				\begin{verbatim}
@@ -184,6 +208,7 @@
 				  "isCpuOnly": false,
 				  "isSmall": true,
 				  "priority": 9000,
+				  "maxAgents": 4,
 				  "files": [
 				    1
 				  ],
@@ -264,6 +289,7 @@
 				  "benchmarkType": "runtime",
 				  "statusTimer": 5,
 				  "priority": 0,
+				  "maxAgents": 4,
 				  "isCpuOnly": false,
 				  "isSmall": false,
 				  "files": []

--- a/doc/user-api/sections/task.tex
+++ b/doc/user-api/sections/task.tex
@@ -86,6 +86,7 @@
 				  "benchmarkType": "speed",
 				  "statusTimer": 5,
 				  "priority": 0,
+				  "maxAgents": 4,
 				  "isCpuOnly": false,
 				  "isSmall": false,
 				  "skipKeyspace": 0,
@@ -228,6 +229,7 @@
 					    2
 					  ],
 					  "priority": 100,
+					  "maxAgents": 4,
 					  "preprocessorId": 0,
 					  "preprocessorCommand": "",
 					  "accessKey": "mykey"
@@ -253,6 +255,7 @@
 					  "crackerVersionId": 2,
 					  "files": [],
 					  "priority": 99,
+					  "maxAgents": 4,
 					  "preprocessorId": 0,
 					  "preprocessorCommand": "",
 					  "accessKey": "mykey"
@@ -367,6 +370,30 @@
 				{
 				  "section": "task",
 				  "request": "setSupertaskPriority",
+				  "response": "OK"
+				}
+				\end{verbatim}
+			}
+		\subsection*{\textit{setTaskMaxAgents}}
+			Set the maximum number of assigned agents for a task. Takes effect when agents request a new chunk.
+			{
+				\color{blue}
+				\begin{verbatim}
+				{
+				  "section": "task",
+				  "request": "setTaskMaxAgents",
+				  "taskId": 7580,
+				  "maxAgents": 2,
+				  "accessKey": "mykey"
+				}
+				\end{verbatim}
+			}
+			{
+				\color{OliveGreen}
+				\begin{verbatim}
+				{
+				  "section": "task",
+				  "request": "setTaskMaxAgents",
 				  "response": "OK"
 				}
 				\end{verbatim}

--- a/src/ajax/get_subtasks.php
+++ b/src/ajax/get_subtasks.php
@@ -42,6 +42,7 @@ foreach ($tasks as $task) {
   $subSet->addValue('chunkTime', $task->getChunkTime());
   $subSet->addValue('taskProgress', $task->getKeyspaceProgress());
   $subSet->addValue('priority', $task->getPriority());
+  $subSet->addValue('maxAgents', $task->getMaxAgents());
   $taskInfo = Util::getTaskInfo($task);
   $fileInfo = Util::getFileInfo($task, $accessGroups);
   $chunkInfo = Util::getChunkInfo($task);

--- a/src/dba/models/Pretask.class.php
+++ b/src/dba/models/Pretask.class.php
@@ -13,10 +13,11 @@ class Pretask extends AbstractModel {
   private $isCpuTask;
   private $useNewBench;
   private $priority;
+  private $maxAgents;
   private $isMaskImport;
   private $crackerBinaryTypeId;
   
-  function __construct($pretaskId, $taskName, $attackCmd, $chunkTime, $statusTimer, $color, $isSmall, $isCpuTask, $useNewBench, $priority, $isMaskImport, $crackerBinaryTypeId) {
+  function __construct($pretaskId, $taskName, $attackCmd, $chunkTime, $statusTimer, $color, $isSmall, $isCpuTask, $useNewBench, $priority, $maxAgents, $isMaskImport, $crackerBinaryTypeId) {
     $this->pretaskId = $pretaskId;
     $this->taskName = $taskName;
     $this->attackCmd = $attackCmd;
@@ -27,6 +28,7 @@ class Pretask extends AbstractModel {
     $this->isCpuTask = $isCpuTask;
     $this->useNewBench = $useNewBench;
     $this->priority = $priority;
+    $this->maxAgents = $maxAgents;
     $this->isMaskImport = $isMaskImport;
     $this->crackerBinaryTypeId = $crackerBinaryTypeId;
   }
@@ -43,6 +45,7 @@ class Pretask extends AbstractModel {
     $dict['isCpuTask'] = $this->isCpuTask;
     $dict['useNewBench'] = $this->useNewBench;
     $dict['priority'] = $this->priority;
+    $dict['maxAgents'] = $this->maxAgents;
     $dict['isMaskImport'] = $this->isMaskImport;
     $dict['crackerBinaryTypeId'] = $this->crackerBinaryTypeId;
     
@@ -144,6 +147,14 @@ class Pretask extends AbstractModel {
   function setPriority($priority) {
     $this->priority = $priority;
   }
+
+  function getMaxAgents() {
+    return $this->maxAgents;
+  }
+  
+  function setMaxAgents($maxAgents) {
+    $this->maxAgents = $maxAgents;
+  }
   
   function getIsMaskImport() {
     return $this->isMaskImport;
@@ -171,6 +182,7 @@ class Pretask extends AbstractModel {
   const IS_CPU_TASK = "isCpuTask";
   const USE_NEW_BENCH = "useNewBench";
   const PRIORITY = "priority";
+  const MAX_AGENTS = "maxAgents";
   const IS_MASK_IMPORT = "isMaskImport";
   const CRACKER_BINARY_TYPE_ID = "crackerBinaryTypeId";
 }

--- a/src/dba/models/PretaskFactory.class.php
+++ b/src/dba/models/PretaskFactory.class.php
@@ -23,7 +23,7 @@ class PretaskFactory extends AbstractModelFactory {
    * @return Pretask
    */
   function getNullObject() {
-    $o = new Pretask(-1, null, null, null, null, null, null, null, null, null, null, null);
+    $o = new Pretask(-1, null, null, null, null, null, null, null, null, null, null, null, null);
     return $o;
   }
   
@@ -33,7 +33,7 @@ class PretaskFactory extends AbstractModelFactory {
    * @return Pretask
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new Pretask($dict['pretaskId'], $dict['taskName'], $dict['attackCmd'], $dict['chunkTime'], $dict['statusTimer'], $dict['color'], $dict['isSmall'], $dict['isCpuTask'], $dict['useNewBench'], $dict['priority'], $dict['isMaskImport'], $dict['crackerBinaryTypeId']);
+    $o = new Pretask($dict['pretaskId'], $dict['taskName'], $dict['attackCmd'], $dict['chunkTime'], $dict['statusTimer'], $dict['color'], $dict['isSmall'], $dict['isCpuTask'], $dict['useNewBench'], $dict['priority'], $dict['maxAgents'], $dict['isMaskImport'], $dict['crackerBinaryTypeId']);
     return $o;
   }
   

--- a/src/dba/models/Task.class.php
+++ b/src/dba/models/Task.class.php
@@ -11,6 +11,7 @@ class Task extends AbstractModel {
   private $keyspace;
   private $keyspaceProgress;
   private $priority;
+  private $maxAgents;
   private $color;
   private $isSmall;
   private $isCpuTask;
@@ -27,7 +28,7 @@ class Task extends AbstractModel {
   private $usePreprocessor;
   private $preprocessorCommand;
   
-  function __construct($taskId, $taskName, $attackCmd, $chunkTime, $statusTimer, $keyspace, $keyspaceProgress, $priority, $color, $isSmall, $isCpuTask, $useNewBench, $skipKeyspace, $crackerBinaryId, $crackerBinaryTypeId, $taskWrapperId, $isArchived, $notes, $staticChunks, $chunkSize, $forcePipe, $usePreprocessor, $preprocessorCommand) {
+  function __construct($taskId, $taskName, $attackCmd, $chunkTime, $statusTimer, $keyspace, $keyspaceProgress, $priority, $maxAgents, $color, $isSmall, $isCpuTask, $useNewBench, $skipKeyspace, $crackerBinaryId, $crackerBinaryTypeId, $taskWrapperId, $isArchived, $notes, $staticChunks, $chunkSize, $forcePipe, $usePreprocessor, $preprocessorCommand) {
     $this->taskId = $taskId;
     $this->taskName = $taskName;
     $this->attackCmd = $attackCmd;
@@ -36,6 +37,7 @@ class Task extends AbstractModel {
     $this->keyspace = $keyspace;
     $this->keyspaceProgress = $keyspaceProgress;
     $this->priority = $priority;
+    $this->maxAgents = $maxAgents;
     $this->color = $color;
     $this->isSmall = $isSmall;
     $this->isCpuTask = $isCpuTask;
@@ -63,6 +65,7 @@ class Task extends AbstractModel {
     $dict['keyspace'] = $this->keyspace;
     $dict['keyspaceProgress'] = $this->keyspaceProgress;
     $dict['priority'] = $this->priority;
+    $dict['maxAgents'] = $this->maxAgents;
     $dict['color'] = $this->color;
     $dict['isSmall'] = $this->isSmall;
     $dict['isCpuTask'] = $this->isCpuTask;
@@ -162,6 +165,14 @@ class Task extends AbstractModel {
     $this->priority = $priority;
   }
   
+  function getMaxAgents() {
+    return $this->maxAgents;
+  }
+  
+  function setMaxAgents($maxAgents) {
+    $this->maxAgents = $maxAgents;
+  }
+
   function getColor() {
     return $this->color;
   }
@@ -290,6 +301,7 @@ class Task extends AbstractModel {
   const KEYSPACE = "keyspace";
   const KEYSPACE_PROGRESS = "keyspaceProgress";
   const PRIORITY = "priority";
+  const MAX_AGENTS = "maxAgents";
   const COLOR = "color";
   const IS_SMALL = "isSmall";
   const IS_CPU_TASK = "isCpuTask";

--- a/src/dba/models/TaskFactory.class.php
+++ b/src/dba/models/TaskFactory.class.php
@@ -23,7 +23,7 @@ class TaskFactory extends AbstractModelFactory {
    * @return Task
    */
   function getNullObject() {
-    $o = new Task(-1, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    $o = new Task(-1, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     return $o;
   }
   
@@ -33,7 +33,7 @@ class TaskFactory extends AbstractModelFactory {
    * @return Task
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new Task($dict['taskId'], $dict['taskName'], $dict['attackCmd'], $dict['chunkTime'], $dict['statusTimer'], $dict['keyspace'], $dict['keyspaceProgress'], $dict['priority'], $dict['color'], $dict['isSmall'], $dict['isCpuTask'], $dict['useNewBench'], $dict['skipKeyspace'], $dict['crackerBinaryId'], $dict['crackerBinaryTypeId'], $dict['taskWrapperId'], $dict['isArchived'], $dict['notes'], $dict['staticChunks'], $dict['chunkSize'], $dict['forcePipe'], $dict['usePreprocessor'], $dict['preprocessorCommand']);
+    $o = new Task($dict['taskId'], $dict['taskName'], $dict['attackCmd'], $dict['chunkTime'], $dict['statusTimer'], $dict['keyspace'], $dict['keyspaceProgress'], $dict['priority'], $dict['maxAgents'], $dict['color'], $dict['isSmall'], $dict['isCpuTask'], $dict['useNewBench'], $dict['skipKeyspace'], $dict['crackerBinaryId'], $dict['crackerBinaryTypeId'], $dict['taskWrapperId'], $dict['isArchived'], $dict['notes'], $dict['staticChunks'], $dict['chunkSize'], $dict['forcePipe'], $dict['usePreprocessor'], $dict['preprocessorCommand']);
     return $o;
   }
   

--- a/src/dba/models/generator.php
+++ b/src/dba/models/generator.php
@@ -177,6 +177,7 @@ $CONF['Pretask'] = [
   'isCpuTask',
   'useNewBench',
   'priority',
+  'maxAgents',
   'isMaskImport',
   'crackerBinaryTypeId'
 ];
@@ -216,6 +217,7 @@ $CONF['Task'] = [
   'keyspace',
   'keyspaceProgress',
   'priority',
+  'maxAgents',
   'color',
   'isSmall',
   'isCpuTask',

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -523,6 +523,7 @@ class Util {
         $set->addValue('isSecret', $hashlist->getIsSecret());
         $set->addValue('usePreprocessor', $task->getUsePreprocessor());
         $set->addValue('priority', $task->getPriority());
+        $set->addValue('maxAgents', $task->getMaxAgents());
         $set->addValue('keyspace', $task->getKeyspace());
         $set->addValue('isActive', $taskInfo[2]);
         $set->addValue('sumProgress', $taskInfo[0]);

--- a/src/inc/api/APIGetTask.class.php
+++ b/src/inc/api/APIGetTask.class.php
@@ -58,6 +58,9 @@ class APIGetTask extends APIBasic {
           DServerLog::log(DServerLog::TRACE, "No best task available and current assigned task is fullfilled", [$this->agent]);
           $this->noTask();
         }
+        if (TaskUtils::isSaturatedByOtherAgents($currentTask, $this->agent)) {
+          $this->noTask();
+        }
         // assignment is still good -> send this task
         DServerLog::log(DServerLog::TRACE, "Current task is running, continue with this", [$this->agent, $currentTask]);
         $this->sendTask($currentTask, $assignment);
@@ -80,6 +83,9 @@ class APIGetTask extends APIBasic {
           $this->sendTask($task, $assignment);
         }
         else {
+          if (TaskUtils::isSaturatedByOtherAgents($currentTask, $this->agent)) {
+            $this->sendTask($task, $assignment);
+          }
           DServerLog::log(DServerLog::TRACE, "Current task is fine, send the more important one", [$this->agent, $currentTask, $task]);
           $this->sendTask(TaskUtils::getImportantTask($task, $currentTask), $assignment);
         }

--- a/src/inc/defines/tasks.php
+++ b/src/inc/defines/tasks.php
@@ -3,6 +3,9 @@
 class DPretaskAction {
   const SET_PRIORITY      = "setPriority";
   const SET_PRIORITY_PERM = DAccessControl::MANAGE_PRETASK_ACCESS;
+
+  const SET_MAX_AGENTS      = "setMaxAgents";
+  const SET_MAX_AGENTS_PERM = DAccessControl::MANAGE_PRETASK_ACCESS;
   
   const DELETE_PRETASK      = "deletePretask";
   const DELETE_PRETASK_PERM = DAccessControl::CREATE_PRETASK_ACCESS;
@@ -99,6 +102,9 @@ class DTaskAction {
   
   const SET_PRIORITY      = "setPriority";
   const SET_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;
+
+  const SET_MAX_AGENTS      = "setMaxAgents";
+  const SET_MAX_AGENTS_PERM = DAccessControl::MANAGE_TASK_ACCESS;
   
   const SET_TOP_PRIORITY = "setTopPriority";
   const SET_TOP_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;

--- a/src/inc/defines/userApi.php
+++ b/src/inc/defines/userApi.php
@@ -43,6 +43,7 @@ class UQueryTask extends UQuery {
   const TASK_CRACKER_VERSION      = "crackerVersionId";
   const TASK_FILES                = "files";
   const TASK_PRIORITY             = "priority";
+  const TASK_MAX_AGENTS           = "maxAgents";
   const TASK_PRINCE               = "isPrince";  // DEPRECATED
   const TASK_PREPROCESSOR_COMMAND = "preprocessorCommand";
   const TASK_PREPROCESSOR         = "preprocessorId";
@@ -57,12 +58,13 @@ class UQueryTask extends UQuery {
   const TASK_BASEFILES     = "basefiles";
   const TASK_ITERFILES     = "iterfiles";
   
-  const PRETASK_PRIORITY  = "priority";
-  const PRETASK_NAME      = "name";
-  const PRETASK_COLOR     = "color";
-  const PRETASK_CHUNKSIZE = "chunksize";
-  const PRETASK_CPU_ONLY  = "isCpuOnly";
-  const PRETASK_SMALL     = "isSmall";
+  const PRETASK_PRIORITY   = "priority";
+  const PRETASK_MAX_AGENTS = "maxAgents";
+  const PRETASK_NAME       = "name";
+  const PRETASK_COLOR      = "color";
+  const PRETASK_CHUNKSIZE  = "chunksize";
+  const PRETASK_CPU_ONLY   = "isCpuOnly";
+  const PRETASK_SMALL      = "isSmall";
 }
 
 class UQueryHashlist extends UQuery {
@@ -227,6 +229,7 @@ class UResponseTask extends UResponse {
   const TASK_BENCH_TYPE           = "benchmarkType";
   const TASK_STATUS               = "statusTimer";
   const TASK_PRIORITY             = "priority";
+  const TASK_MAX_AGENTS           = "maxAgents";
   const TASK_CPU_ONLY             = "isCpuOnly";
   const TASK_SMALL                = "isSmall";
   const TASK_SKIP                 = "skipKeyspace";
@@ -264,6 +267,7 @@ class UResponseTask extends UResponse {
   const PRETASK_BENCH_TYPE = "benchmarkType";
   const PRETASK_STATUS     = "statusTimer";
   const PRETASK_PRIORITY   = "priority";
+  const PRETASK_MAX_AGENTS = "maxAgents";
   const PRETASK_CPU_ONLY   = "isCpuOnly";
   const PRETASK_SMALL      = "isSmall";
   const PRETASK_FILES      = "files";
@@ -607,6 +611,7 @@ class USectionTask extends UApi {
   const SET_TASK_COLOR             = "setTaskColor";
   const SET_TASK_CPU_ONLY          = "setTaskCpuOnly";
   const SET_TASK_SMALL             = "setTaskSmall";
+  const SET_TASK_MAX_AGENTS        = "setTaskMaxAgents";
   const TASK_UNASSIGN_AGENT        = "taskUnassignAgent";
   const TASK_ASSIGN_AGENT          = "taskAssignAgent";
   const DELETE_TASK                = "deleteTask";
@@ -677,13 +682,14 @@ class USectionPretask extends UApi {
   const GET_PRETASK    = "getPretask";
   const CREATE_PRETASK = "createPretask";
   
-  const SET_PRETASK_PRIORITY  = "setPretaskPriority";
-  const SET_PRETASK_NAME      = "setPretaskName";
-  const SET_PRETASK_COLOR     = "setPretaskColor";
-  const SET_PRETASK_CHUNKSIZE = "setPretaskChunksize";
-  const SET_PRETASK_CPU_ONLY  = "setPretaskCpuOnly";
-  const SET_PRETASK_SMALL     = "setPretaskSmall";
-  const DELETE_PRETASK        = "deletePretask";
+  const SET_PRETASK_PRIORITY   = "setPretaskPriority";
+  const SET_PRETASK_MAX_AGENTS = "setPretaskMaxAgents";
+  const SET_PRETASK_NAME       = "setPretaskName";
+  const SET_PRETASK_COLOR      = "setPretaskColor";
+  const SET_PRETASK_CHUNKSIZE  = "setPretaskChunksize";
+  const SET_PRETASK_CPU_ONLY   = "setPretaskCpuOnly";
+  const SET_PRETASK_SMALL      = "setPretaskSmall";
+  const DELETE_PRETASK         = "deletePretask";
   
   public function describe($constant) {
     switch ($constant) {

--- a/src/inc/handlers/PretaskHandler.class.php
+++ b/src/inc/handlers/PretaskHandler.class.php
@@ -33,6 +33,10 @@ class PretaskHandler implements Handler {
             die();
           }
           break;
+        case DPretaskAction::SET_MAX_AGENTS:
+          AccessControl::getInstance()->checkPermission(DPretaskAction::SET_MAX_AGENTS_PERM);
+          PretaskUtils::setMaxAgents($_POST['pretaskId'], $_POST['maxAgents']);
+          break;
         case DPretaskAction::SET_CPU_TASK:
           AccessControl::getInstance()->checkPermission(DPretaskAction::SET_CPU_TASK_PERM);
           PretaskUtils::setCpuOnlyTask($_POST['pretaskId'], $_POST['isCpu']);
@@ -43,7 +47,7 @@ class PretaskHandler implements Handler {
           break;
         case DPretaskAction::CREATE_TASK:
           AccessControl::getInstance()->checkPermission(DPretaskAction::CREATE_TASK_PERM);
-          PretaskUtils::createPretask($_POST['name'], $_POST['cmdline'], $_POST['chunk'], $_POST['status'], $_POST['color'], $_POST['cpuOnly'], $_POST['isSmall'], $_POST['benchType'], $_POST['adfile'], $_POST['crackerBinaryTypeId']);
+          PretaskUtils::createPretask($_POST['name'], $_POST['cmdline'], $_POST['chunk'], $_POST['status'], $_POST['color'], $_POST['cpuOnly'], $_POST['isSmall'], $_POST['benchType'], $_POST['adfile'], $_POST['crackerBinaryTypeId'], $_POST['maxAgents']);
           header("Location: pretasks.php");
           die();
         case DPretaskAction::CHANGE_ATTACK:

--- a/src/inc/handlers/TaskHandler.class.php
+++ b/src/inc/handlers/TaskHandler.class.php
@@ -77,6 +77,10 @@ class TaskHandler implements Handler {
           AccessControl::getInstance()->checkPermission(DTaskAction::SET_PRIORITY_PERM);
           TaskUtils::updatePriority($_POST["task"], $_POST['priority'], Login::getInstance()->getUser());
           break;
+        case DTaskAction::SET_MAX_AGENTS:
+            AccessControl::getInstance()->checkPermission(DTaskAction::SET_MAX_AGENTS_PERM);
+            TaskUtils::updateMaxAgents($_POST["task"], $_POST['maxAgents'], Login::getInstance()->getUser());
+            break;
         case DTaskAction::SET_TOP_PRIORITY:
           AccessControl::getInstance()->checkPermission(DTaskAction::SET_PRIORITY_PERM);
           TaskUtils::updatePriority($_POST["task"], -1, Login::getInstance()->getUser(), true);
@@ -147,6 +151,7 @@ class TaskHandler implements Handler {
     $staticChunking = intval(@$_POST['staticChunking']);
     $chunkSize = intval(@$_POST['chunkSize']);
     $priority = intval(@$_POST['priority']);
+    $maxAgents = intval(@$_POST['maxAgents']);
     $enforcePipe = intval(@$_POST['enforcePipe']);
     $usePreprocessor = intval(@$_POST['usePreprocessor']);
     $preprocessorCommand = @$_POST['preprocessorCommand'];
@@ -255,6 +260,7 @@ class TaskHandler implements Handler {
         0,
         0,
         $priority,
+        $maxAgents,
         $color,
         $isSmall,
         $isCpuTask,
@@ -288,6 +294,7 @@ class TaskHandler implements Handler {
         0,
         0,
         $priority,
+        $copy->getMaxAgents(),
         $copy->getColor(),
         $copy->getIsSmall(),
         $copy->getIsCpuTask(),

--- a/src/inc/user-api/UserAPIPretask.class.php
+++ b/src/inc/user-api/UserAPIPretask.class.php
@@ -16,6 +16,9 @@ class UserAPIPretask extends UserAPIBasic {
         case USectionPretask::SET_PRETASK_PRIORITY:
           $this->setPretaskPriority($QUERY);
           break;
+        case USectionPretask::SET_PRETASK_MAX_AGENTS:
+          $this->setPretaskMaxAgents($QUERY);
+          break;
         case USectionpretask::SET_PRETASK_NAME:
           $this->setPretaskName($QUERY);
           break;
@@ -131,6 +134,18 @@ class UserAPIPretask extends UserAPIBasic {
    * @param array $QUERY
    * @throws HTException
    */
+  private function setPretaskMaxAgents($QUERY) {
+    if (!isset($QUERY[UQueryTask::PRETASK_ID]) || !isset($QUERY[UQueryTask::PRETASK_MAX_AGENTS])) {
+      throw new HTException("Invalid query!");
+    }
+    PretaskUtils::setMaxAgents($QUERY[UQueryTask::PRETASK_ID], $QUERY[UQueryTask::PRETASK_MAX_AGENTS], $this->user);
+    $this->sendSuccessResponse($QUERY);
+  }
+
+  /**
+   * @param array $QUERY
+   * @throws HTException
+   */
   private function createPretask($QUERY) {
     $toCheck = [
       UQueryTask::TASK_NAME,
@@ -143,7 +158,8 @@ class UserAPIPretask extends UserAPIBasic {
       UQueryTask::TASK_SMALL,
       UQueryTask::TASK_CRACKER_TYPE,
       UQueryTask::TASK_FILES,
-      UQueryTask::TASK_PRIORITY
+      UQueryTask::TASK_PRIORITY,
+      UQueryTask::TASK_MAX_AGENTS
     ];
     foreach ($toCheck as $input) {
       if (!isset($QUERY[$input])) {
@@ -153,6 +169,10 @@ class UserAPIPretask extends UserAPIBasic {
     $priority = $QUERY[UQueryTask::TASK_PRIORITY];
     if ($priority < 0) {
       $priority = 0;
+    }
+    $maxAgents = $QUERY[UQueryTask::TASK_MAX_AGENTS];
+    if ($maxAgents < 0) {
+      $maxAgents = 0;
     }
     PretaskUtils::createPretask(
       $QUERY[UQueryTask::TASK_NAME],
@@ -165,6 +185,7 @@ class UserAPIPretask extends UserAPIBasic {
       ($QUERY[UQueryTask::TASK_BENCHTYPE] == 'speed') ? 1 : 0,
       $QUERY[UQueryTask::TASK_FILES],
       $QUERY[UQueryTask::TASK_CRACKER_TYPE],
+      $maxAgents,
       $priority
     );
     $this->sendSuccessResponse($QUERY);
@@ -192,6 +213,7 @@ class UserAPIPretask extends UserAPIBasic {
       UResponseTask::PRETASK_BENCH_TYPE => ($pretask->getUseNewBench() == 1) ? "speed" : "runtime",
       UResponseTask::PRETASK_STATUS => (int)$pretask->getStatusTimer(),
       UResponseTask::PRETASK_PRIORITY => (int)$pretask->getPriority(),
+      UResponseTask::PRETASK_MAX_AGENTS => (int)$pretask->getMaxAgents(),
       UResponseTask::PRETASK_CPU_ONLY => ($pretask->getIsCpuTask() == 1) ? true : false,
       UResponseTask::PRETASK_SMALL => ($pretask->getIsSmall() == 1) ? true : false
     ];

--- a/src/inc/user-api/UserAPITask.class.php
+++ b/src/inc/user-api/UserAPITask.class.php
@@ -49,6 +49,9 @@ class UserAPITask extends UserAPIBasic {
         case USectionTask::SET_TASK_SMALL:
           $this->setSmallTask($QUERY);
           break;
+        case USectionTask::SET_TASK_MAX_AGENTS:
+          $this->setTaskMaxAgents($QUERY);
+          break;
         case USectionTask::TASK_UNASSIGN_AGENT:
           $this->unassignAgent($QUERY);
           break;
@@ -196,6 +199,18 @@ class UserAPITask extends UserAPIBasic {
       throw new HTException("Invalid query!");
     }
     AgentUtils::assign($QUERY[UQueryTask::AGENT_ID], $QUERY[UQueryTask::TASK_ID], $this->user);
+    $this->sendSuccessResponse($QUERY);
+  }
+
+    /**
+   * @param array $QUERY
+   * @throws HTException
+   */
+  private function setTaskMaxAgents($QUERY) {
+    if (!isset($QUERY[UQueryTask::TASK_ID]) || !isset($QUERY[UQueryTask::TASK_MAX_AGENTS])) {
+      throw new HTException("Invalid query!");
+    }
+    TaskUtils::setTaskMaxAgents($QUERY[UQueryTask::TASK_ID], $QUERY[UQueryTask::TASK_MAX_AGENTS], $this->user);
     $this->sendSuccessResponse($QUERY);
   }
   
@@ -357,6 +372,7 @@ class UserAPITask extends UserAPIBasic {
       $QUERY[UQueryTask::TASK_PREPROCESSOR_COMMAND],
       $QUERY[UQueryTask::TASK_SKIP],
       $QUERY[UQueryTask::TASK_PRIORITY],
+      $QUERY[UQueryTask::TASK_MAX_AGENTS],
       $QUERY[UQueryTask::TASK_FILES],
       $QUERY[UQueryTask::TASK_CRACKER_VERSION],
       $this->user
@@ -454,6 +470,7 @@ class UserAPITask extends UserAPIBasic {
       UResponseTask::TASK_BENCH_TYPE => ($task->getUseNewBench() == 1) ? "speed" : "runtime",
       UResponseTask::TASK_STATUS => (int)$task->getStatusTimer(),
       UResponseTask::TASK_PRIORITY => (int)$task->getPriority(),
+      UResponseTask::TASK_MAX_AGENTS => (int)$task->getMaxAgents(),
       UResponseTask::TASK_CPU_ONLY => ($task->getIsCpuTask() == 1) ? true : false,
       UResponseTask::TASK_SMALL => ($task->getIsSmall() == 1) ? true : false,
       UResponseTask::TASK_SKIP => (int)$task->getSkipKeyspace(),

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -121,6 +121,7 @@ class HashlistUtils {
           0,
           0,
           $taskPriority,
+          $task->getMaxAgents(),
           $task->getColor(),
           $task->getIsSmall(),
           $task->getIsCpuTask(),

--- a/src/inc/utils/PretaskUtils.class.php
+++ b/src/inc/utils/PretaskUtils.class.php
@@ -42,6 +42,7 @@ class PretaskUtils {
       $copy->getIsCpuTask(),
       $copy->getUseNewBench(),
       0,
+      $copy->getMaxAgents(),
       0,
       $copy->getCrackerBinaryTypeId()
     );
@@ -61,6 +62,7 @@ class PretaskUtils {
       0,
       0,
       SConfig::getInstance()->getVal(DConfig::DEFAULT_BENCH),
+      0,
       0,
       0,
       0
@@ -110,6 +112,20 @@ class PretaskUtils {
       throw new HTException("Priority needs to be a number!");
     }
     Factory::getPretaskFactory()->set($pretask, Pretask::PRIORITY, intval($priority));
+  }
+
+    /**
+   * @param int $pretaskId
+   * @param int $maxAgents
+   * @throws HTException
+   */
+  public static function setMaxAgents($pretaskId, $maxAgents) {
+    $pretask = PretaskUtils::getPretask($pretaskId);
+    if (!is_numeric($maxAgents)) {
+      throw new HTException("Max agents needs to be a number!");
+    }
+    $maxAgents = intval($maxAgents);
+    Factory::getPretaskFactory()->set($pretask, Pretask::MAX_AGENTS, $maxAgents);
   }
   
   /**
@@ -240,6 +256,7 @@ class PretaskUtils {
       0,
       0,
       $pretask->getPriority(),
+      $pretask->getMaxAgents(),
       $pretask->getColor(),
       $pretask->getIsSmall(),
       $pretask->getIsCpuTask(),
@@ -275,10 +292,11 @@ class PretaskUtils {
    * @param int $benchmarkType
    * @param array $files
    * @param int $crackerBinaryTypeId
+   * @param int $maxAgents
    * @param int $priority
    * @throws HTException
    */
-  public static function createPretask($name, $cmdLine, $chunkTime, $statusTimer, $color, $cpuOnly, $isSmall, $benchmarkType, $files, $crackerBinaryTypeId, $priority = 0) {
+  public static function createPretask($name, $cmdLine, $chunkTime, $statusTimer, $color, $cpuOnly, $isSmall, $benchmarkType, $files, $crackerBinaryTypeId, $maxAgents, $priority = 0) {
     $crackerBinaryType = Factory::getCrackerBinaryTypeFactory()->get($crackerBinaryTypeId);
     
     if (strlen($name) == 0) {
@@ -295,6 +313,7 @@ class PretaskUtils {
     }
     $chunkTime = intval($chunkTime);
     $statusTimer = intval($statusTimer);
+    $maxAgents = intval($maxAgents);
     if (strlen($color) > 0 && preg_match("/[0-9A-Fa-f]{6}/", $color) == 0) {
       $color = "";
     }
@@ -323,6 +342,7 @@ class PretaskUtils {
       $cpuOnly,
       $benchmarkType,
       $priority,
+      $maxAgents,
       0,
       $crackerBinaryType->getId()
     );

--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -120,6 +120,7 @@ class SupertaskUtils {
         $benchtype,
         $priority,
         0,
+        0,
         $crackerBinaryType->getId()
       );
       $pretask = Factory::getPretaskFactory()->save($pretask);
@@ -286,6 +287,7 @@ class SupertaskUtils {
         0,
         0,
         $pretask->getPriority(),
+        $pretask->getMaxAgents(),
         $pretask->getColor(),
         $pretask->getIsSmall(),
         $pretask->getIsCpuTask(),
@@ -431,6 +433,7 @@ class SupertaskUtils {
         $isCpu,
         $newBench,
         $priority,
+        0,
         1,
         $crackerBinaryType->getId()
       );

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -674,6 +674,7 @@ CREATE TABLE `Pretask` (
   `isCpuTask`           TINYINT(4)   NOT NULL,
   `useNewBench`         TINYINT(4)   NOT NULL,
   `priority`            INT(11)      NOT NULL,
+  `maxAgents`           INT(11)      NOT NULL,
   `isMaskImport`        TINYINT(4)   NOT NULL,
   `crackerBinaryTypeId` INT(11)      NOT NULL
 ) ENGINE = InnoDB;
@@ -736,6 +737,7 @@ CREATE TABLE `Task` (
   `keyspace`            BIGINT(20)   NOT NULL,
   `keyspaceProgress`    BIGINT(20)   NOT NULL,
   `priority`            INT(11)      NOT NULL,
+  `maxAgents`           INT(11)      NOT NULL,
   `color`               VARCHAR(20)  NULL,
   `isSmall`             TINYINT(4)   NOT NULL,
   `isCpuTask`           TINYINT(4)   NOT NULL,

--- a/src/install/updates/update_v0.12.x_v0.x.x.php
+++ b/src/install/updates/update_v0.12.x_v0.x.x.php
@@ -136,3 +136,13 @@ if (!isset($PRESENT["v0.12.x_fileLineCount"])) {
   }
   $EXECUTED["v0.12.x_fileLineCount"] = true;
 }
+
+if (!isset($PRESENT["v0.12.x_maxAgents_pretask_task"])) {
+  if (!Util::databaseColumnExists("Pretask", "maxAgents")) {
+    Factory::getFileFactory()->getDB()->query("ALTER TABLE `Pretask` ADD `maxAgents` INT(11) NOT NULL;");
+  }
+  if (!Util::databaseColumnExists("Task", "maxAgents")) {
+    Factory::getFileFactory()->getDB()->query("ALTER TABLE `Task` ADD `maxAgents` INT(11) NOT NULL;");
+  }
+  $EXECUTED["v0.12.x_maxAgents_pretask_task"] = true;
+}

--- a/src/templates/pretasks/detail.template.html
+++ b/src/templates/pretasks/detail.template.html
@@ -117,6 +117,22 @@
         </td>
       </tr>
       <tr>
+        <td>Max agents:</td>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_PRETASK_ACCESS]])]]}}
+            <form class='form-inline' action="pretasks.php?id=[[pretask.getId()]]" method="POST">
+              <input type="hidden" name="action" value="[[$DPretaskAction::SET_MAX_AGENTS]]">
+              <input type="hidden" name="pretaskId" value="[[pretask.getId()]]">
+              <input type="hidden" name="csrf" value="[[csrf]]">
+              <input type="text" class='form-control' name="maxAgents" size="4" value="[[pretask.getMaxAgents()]]" title="Max agents">&nbsp;&nbsp;
+              <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}}' data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+            </form>
+          {{ELSE}}
+            [[pretask.getMaxAgents()]]
+          {{ENDIF}}
+        </td>
+      </tr>
+      <tr>
         <td>Is CPU only task:</td>
         <td>
           {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_PRETASK_ACCESS]])]]}}

--- a/src/templates/pretasks/index.template.html
+++ b/src/templates/pretasks/index.template.html
@@ -12,6 +12,7 @@
           <th>Attack command</th>
           <th>Files</th>
           <th>Priority</th>
+          <th>Max agents</th>
           <th>Action</th>
         </tr>
       </thead>
@@ -45,6 +46,19 @@
 					    {{ELSE}}
 						    [[task.getVal('Task').getPriority()]]
 					    {{ENDIF}}
+            </td>
+            <td data-sort="[[task.getVal('Task').getMaxAgents()]]">
+                {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_PRETASK_ACCESS]])]]}}
+                <form class='form-inline' action="pretasks.php" method="POST">
+                    <input type="hidden" name="action" value="[[$DPretaskAction::SET_MAX_AGENTS]]">
+                    <input type="hidden" name="pretaskId" value="[[task.getVal('Task').getId()]]">
+                    <input type="hidden" name="csrf" value="[[csrf]]">
+                    <input type="text" class='form-control' name="maxAgents" size="4" value="[[task.getVal('Task').getMaxAgents()]]" title="Max agents">
+                    <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}} mx-1' data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+                </form>
+                {{ELSE}}
+                  [[task.getVal('Task').getMaxAgents()]]
+                {{ENDIF}}
             </td>
             <td>
 					    {{IF [[accessControl.hasPermission([[$DAccessControl::CREATE_PRETASK_ACCESS]])]]}}

--- a/src/templates/tasks/detail.template.html
+++ b/src/templates/tasks/detail.template.html
@@ -163,6 +163,22 @@
         </td>
       </tr>
       <tr>
+        <td>Max agents:</td>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
+            <form class='form-inline' action="tasks.php?id=[[task.getId()]]" method="POST">
+              <input type="hidden" name="action" value="[[$DTaskAction::SET_MAX_AGENTS]]">
+              <input type="hidden" name="task" value="[[task.getId()]]">
+              <input type="hidden" name="csrf" value="[[csrf]]">
+              <input type="text" class='form-control' name="maxAgents" size="4" value="[[task.getMaxAgents()]]" title="Max agents">&nbsp;&nbsp;
+              <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}}' data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+            </form>
+          {{ELSE}}
+            [[task.getMaxAgents()]]
+          {{ENDIF}}
+        </td>
+      </tr>
+      <tr>
         <td>Is CPU only task:</td>
         <td>
           {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}

--- a/src/templates/tasks/index.template.html
+++ b/src/templates/tasks/index.template.html
@@ -36,8 +36,8 @@
           <th>Dispatched/Searched</th>
           <th>Cracked</th>
           <th>Agents</th>
-          <th>Files</th>
           <th>Task Priority</th>
+          <th>Max agents</th>
           <th style="min-width: 170px;">Action</th>
         </tr>
       </thead>

--- a/src/templates/tasks/new.template.html
+++ b/src/templates/tasks/new.template.html
@@ -46,6 +46,13 @@
               <input type="number" class='form-control' name="priority" value="[[copy.getPriority()]]" title="Priority">
             </td>
           </tr>
+        </tr>
+        <tr>
+          <td>Maximum number of agents:</td>
+          <td>
+            <input type="number" class='form-control' name="maxAgents" value="[[copy.getMaxAgents()]]" title="Max Agents">
+          </td>
+        </tr>
           <tr>
             <td>Task notes:</td>
             <td>

--- a/src/templates/tasks/normal.template.html
+++ b/src/templates/tasks/normal.template.html
@@ -5,6 +5,9 @@
   <td title="[[htmlentities([[set.getVal('attackCmd')]], ENT_QUOTES, 'UTF-8')]]">
     <a href="tasks.php?id=[[set.getVal('taskId')]]">[[set.getVal('taskName')]]</a>
     [[Util::tickdone([[set.getVal('sumProgress')]], [[set.getVal('keyspace')]])]]
+    {{IF [[set.getVal('fileSecret')]]}}
+      <span class="fas fa-lock" aria-hidden="true"></span>
+    {{ENDIF}}
     {{IF [[set.getVal('isActive')]]}}
       <i class="fas fa-spinner fa-spin"></i>
     {{ENDIF}}
@@ -56,17 +59,6 @@
       {{ENDIF}}
     {{ENDIF}}
   </td>
-  <td style='min-width: 95px' data-sort="[[set.getVal('fileSizes')]]">
-    {{IF [[set.getVal('numFiles')]] > 0}}
-      [[set.getVal('numFiles')]]
-    {{ENDIF}}
-    {{IF [[set.getVal('fileSecret')]]}}
-      <span class="fas fa-lock" aria-hidden="true"></span>
-    {{ENDIF}}
-    {{IF [[set.getVal('numFiles')]] > 0}}
-      <br>([[Util::nicenum([[set.getVal('fileSizes')]])]]B)
-    {{ENDIF}}
-  </td>
   <td style='min-width: 130px' data-sort="[[set.getVal('priority')]]">
     {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
       <form class="form-inline" action="tasks.php" method="POST">
@@ -78,6 +70,19 @@
       </form>
     {{ELSE}}
       [[set.getVal('priority')]]
+    {{ENDIF}}
+  </td>
+  <td style='min-width: 130px' data-sort="[[set.getVal('maxAgents')]]">
+    {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
+      <form class="form-inline" action="tasks.php" method="POST">
+        <input type='hidden' name='action' value='[[$DTaskAction::SET_MAX_AGENTS]]'>
+        <input type="hidden" name="task" value="[[set.getVal('taskId')]]">
+        <input type="hidden" name="csrf" value="[[csrf]]">
+        <input type="text" class='form-control' style='width: 60px;' name="maxAgents" size="4" value="[[set.getVal('maxAgents')]]" title="Max agents">
+        <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}} mx-1' data-toggle="tooltip" data-placement="top" title="Set max agents"><i class="fas fa-save" aria-hidden="true"></i></button>
+      </form>
+    {{ELSE}}
+      [[set.getVal('maxAgents')]]
     {{ENDIF}}
   </td>
   <td style='min-width: 120px'>

--- a/src/templates/tasks/subtasks.template.html
+++ b/src/templates/tasks/subtasks.template.html
@@ -14,6 +14,9 @@
         [[subTask.getVal('taskName')]]
       {{ENDIF}}
       [[Util::tickdone([[subTask.getVal('sumProgress')]], [[subTask.getVal('keyspace')]])]]
+      {{IF [[subTask.getVal('fileSecret')]]}}
+      <span class="fas fa-lock" aria-hidden="true"></span>
+      {{ENDIF}}
       {{IF [[subTask.getVal('isActive')]] == 1 && [[subTask.getVal('sumProgress')]] < [[subTask.getVal('keyspace')]]}}
         <i class="fas fa-spinner fa-spin"></i>
       {{ENDIF}}
@@ -52,17 +55,6 @@
         {{ENDIF}}
       {{ENDIF}}
     </td>
-    <td style='min-width: 95px' data-sort="[[subTask.getVal('filesSize')]]">
-      {{IF [[subTask.getVal('numFiles')]] > 0}}
-        [[subTask.getVal('numFiles')]]
-      {{ENDIF}}
-      {{IF [[subTask.getVal('fileSecret')]]}}
-        <span class="fas fa-lock" aria-hidden="true"></span>
-      {{ENDIF}}
-      {{IF [[subTask.getVal('numFiles')]] > 0}}
-        <br>([[Util::nicenum([[subTask.getVal('filesSize')]])]]B)
-      {{ENDIF}}
-    </td>
     <td style='min-width: 130px' data-sort="[[subTask.getVal('priority')]]">
       {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
         <form class="form-inline" action="tasks.php" method="POST">
@@ -74,6 +66,19 @@
         </form>
       {{ELSE}}
         [[subTask.getVal('priority')]]
+      {{ENDIF}}
+    </td>
+    <td style='min-width: 130px' data-sort="[[subTask.getVal('maxAgents')]]">
+      {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
+      <form class="form-inline" action="tasks.php" method="POST">
+        <input type='hidden' name='action' value='[[$DTaskAction::SET_MAX_AGENTS]]'>
+        <input type="hidden" name="task" value="[[subTask.getVal('taskId')]]">
+        <input type="hidden" name="csrf" value="[[csrf]]">
+        <input type="text" class='form-control' style='width: 60px;' name="maxAgents" size="4" value="[[subTask.getVal('maxAgents')]]" title="Max agents">
+        <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}} mx-1' data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+      </form>
+      {{ELSE}}
+        [[subTask.getVal('maxAgents')]]
       {{ENDIF}}
     </td>
     <td style='min-width: 120px'>

--- a/src/templates/tasks/supertask.template.html
+++ b/src/templates/tasks/supertask.template.html
@@ -33,17 +33,6 @@
       [[set.getVal('numAssignments')]]
     {{ENDIF}}
   </td>
-  <td style='min-width: 95px' data-sort="[[set.getVal('filesSize')]]">
-    {{IF [[set.getVal('numFiles')]] > 0}}
-      [[set.getVal('numFiles')]]
-    {{ENDIF}}
-    {{IF [[set.getVal('fileSecret')]]}}
-      <span class="fas fa-lock" aria-hidden="true"></span>
-    {{ENDIF}}
-    {{IF [[set.getVal('numFiles')]] > 0}}
-      <br>([[Util::nicenum([[set.getVal('filesSize')]])]]B)
-    {{ENDIF}}
-  </td>
   <td style='min-width: 130px' data-sort="[[set.getVal('priority')]]">
     {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
       <form class="form-inline" action="tasks.php" method="POST">
@@ -55,6 +44,11 @@
       </form>
     {{ELSE}}
       [[set.getVal('priority')]]
+    {{ENDIF}}
+  </td>
+  <td class='num'>
+    {{IF [[set.getVal('maxAgents')]] > 0}}
+      [[set.getVal('maxAgents')]]
     {{ENDIF}}
   </td>
   <td style='min-width: 120px'>
@@ -100,8 +94,8 @@
                       <th>Dispatched / Searched</th>
                       <th>Cracked</th>
                       <th>Agents</th>
-                      <th>Files</th>
                       <th>Priority</th>
+                      <th>Max agents</th>
                       <th>Action</th>
                     </tr>
                   </thead>


### PR DESCRIPTION
This is a proposal implementation for limiting the maximum amount of agents working on a task, allowing the surplus of agents to work on tasks with lower priority. It is currently implemented for tasks only, the idea is that if this gets approved (after any feedback and changes), we will implement it for super tasks as well.

We added the possibility to configure the maximum amount of agents at a couple of location in the UI. Because the task overview table would become too large, we made a change by removing the files column, but showing if they are linked to any secret ones by rendering the padlock behind the task name. See the pictures below.

![create-task](https://user-images.githubusercontent.com/105731402/169008659-90a86d39-d858-47d2-b73b-39ce27c4472b.png)
![task-index](https://user-images.githubusercontent.com/105731402/169008695-5425f270-4e61-464a-a683-c878eadf0228.png)
![supertask-info](https://user-images.githubusercontent.com/105731402/169008692-16ec5e65-e0e1-4d6e-ad6f-28a98db009a7.png)

