### PR TITLE
Change access group for hashlist not working

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -24,6 +24,7 @@
 - Time of Zaps inserted is now saved.
 - Fixed unable to unassign agent from the task detail screen.
 - Fixed speed graph incorrect when status timer is different from servers default.
+- Fixed access group not being changed on Hashlist detailed screen.
 
 ## Enhancements
 

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -1099,6 +1099,10 @@ class HashlistUtils {
       throw new HTException("No access to this group!");
     }
     
+    $qF = new QueryFilter(Hashlist::HASHLIST_ID, $hashlist->getId(), "=");
+    $uS = new UpdateSet(Hashlist::ACCESS_GROUP_ID, $accessGroup->getId(), "=");
+    Factory::getHashlistFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
+
     $qF = new QueryFilter(TaskWrapper::HASHLIST_ID, $hashlist->getId(), "=");
     $uS = new UpdateSet(TaskWrapper::ACCESS_GROUP_ID, $accessGroup->getId());
     Factory::getTaskWrapperFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);


### PR DESCRIPTION
Fixes #765 

In the hashlist changeAccessGroup in the Hashlist util there was only a query for change all the task wrappers involved with the hashlist and not changing the accessgroup of the accesslist it self.

This resulted in only one update query:

`UPDATE TaskWrapper SET accessGroupId=? WHERE hashlistId=?`

With this new change two update queries will be ran:

`
UPDATE TaskWrapper SET accessGroupId=? WHERE hashlistId=?
UPDATE Hashlist SET accessGroupId=? WHERE hashlistId=?
`

This results in the accessgroup also being changed on the hashlist:

![image](https://user-images.githubusercontent.com/4386076/169487755-eca6b106-8882-4210-8520-1c8113391f45.png)
