### PR TITLE
Allow environment specific customization of dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
 FROM php:8-apache  
 
+ARG DEV_CONTAINER_USER_CMD
+
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
+RUN [ -n "${DEV_CONTAINER_USER_CMD}" ] \
+    && echo "${DEV_CONTAINER_USER_CMD}" | sh
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - DEV_CONTAINER_USER_CMD
     depends_on:
       - db
     ports:


### PR DESCRIPTION
With this improvement, it is possible to specify user commands outside of the Dockerfile, allowing for environment specific configuration. One can add them in a local `.devcontainer/.env` file to customize the container, e.g.:
```
DEV_CONTAINER_USER_CMD='echo configuration > setup.ini'
``` 