### PR TITLE
Added column "Created by" to hashlist overview

### DIFF
--- a/src/dba/models/Hashlist.class.php
+++ b/src/dba/models/Hashlist.class.php
@@ -17,8 +17,9 @@ class Hashlist extends AbstractModel {
   private $notes;
   private $brainId;
   private $brainFeatures;
+  private $creatorId;
   
-  function __construct($hashlistId, $hashlistName, $format, $hashTypeId, $hashCount, $saltSeparator, $cracked, $isSecret, $hexSalt, $isSalted, $accessGroupId, $notes, $brainId, $brainFeatures) {
+  function __construct($hashlistId, $hashlistName, $format, $hashTypeId, $hashCount, $saltSeparator, $cracked, $isSecret, $hexSalt, $isSalted, $accessGroupId, $notes, $brainId, $brainFeatures, $creatorId) {
     $this->hashlistId = $hashlistId;
     $this->hashlistName = $hashlistName;
     $this->format = $format;
@@ -33,6 +34,7 @@ class Hashlist extends AbstractModel {
     $this->notes = $notes;
     $this->brainId = $brainId;
     $this->brainFeatures = $brainFeatures;
+    $this->creatorId = $creatorId;
   }
   
   function getKeyValueDict() {
@@ -51,7 +53,8 @@ class Hashlist extends AbstractModel {
     $dict['notes'] = $this->notes;
     $dict['brainId'] = $this->brainId;
     $dict['brainFeatures'] = $this->brainFeatures;
-    
+    $dict['creatorId'] = $this->creatorId;
+
     return $dict;
   }
   
@@ -121,6 +124,14 @@ class Hashlist extends AbstractModel {
   
   function getCracked() {
     return $this->cracked;
+  }
+
+  function getCreatorId() {
+    return $this->creator;
+  }
+
+  function setCreatorId($creatorId) {
+    $this->creatorId = $creatorId;
   }
   
   function setCracked($cracked) {
@@ -197,4 +208,5 @@ class Hashlist extends AbstractModel {
   const NOTES = "notes";
   const BRAIN_ID = "brainId";
   const BRAIN_FEATURES = "brainFeatures";
+  const CREATOR = "creatorId";
 }

--- a/src/dba/models/HashlistFactory.class.php
+++ b/src/dba/models/HashlistFactory.class.php
@@ -23,7 +23,7 @@ class HashlistFactory extends AbstractModelFactory {
    * @return Hashlist
    */
   function getNullObject() {
-    $o = new Hashlist(-1, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    $o = new Hashlist(-1, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     return $o;
   }
   
@@ -33,7 +33,7 @@ class HashlistFactory extends AbstractModelFactory {
    * @return Hashlist
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new Hashlist($dict['hashlistId'], $dict['hashlistName'], $dict['format'], $dict['hashTypeId'], $dict['hashCount'], $dict['saltSeparator'], $dict['cracked'], $dict['isSecret'], $dict['hexSalt'], $dict['isSalted'], $dict['accessGroupId'], $dict['notes'], $dict['brainId'], $dict['brainFeatures']);
+    $o = new Hashlist($dict['hashlistId'], $dict['hashlistName'], $dict['format'], $dict['hashTypeId'], $dict['hashCount'], $dict['saltSeparator'], $dict['cracked'], $dict['isSecret'], $dict['hexSalt'], $dict['isSalted'], $dict['accessGroupId'], $dict['notes'], $dict['brainId'], $dict['brainFeatures'], $dict['creatorId']);
     return $o;
   }
   

--- a/src/hashlists.php
+++ b/src/hashlists.php
@@ -136,8 +136,16 @@ else {
   /** @var $joinedHashlists Hashlist[] */
   $joinedHashlists = $joined[Factory::getHashlistFactory()->getModelName()];
   $hashlists = array();
+
+  // Get User Factory
+  $UserFactory = Factory::getUserFactory();
+
   for ($x = 0; $x < sizeof($joinedHashlists); $x++) {
-    $hashlists[] = new DataSet(['hashlist' => $joinedHashlists[$x], 'hashtype' => $joined[Factory::getHashTypeFactory()->getModelName()][$x]]);
+    // Add the creator details to the dataset in order to render a username, not just the ID of the user
+    $creatorId = $joinedHashlists[$x]->getCreator();
+    $creatorUsername = $UserFactory->get($creatorId)->getUsername();
+    
+    $hashlists[] = new DataSet(['hashlist' => $joinedHashlists[$x], 'hashtype' => $joined[Factory::getHashTypeFactory()->getModelName()][$x], 'creator' => $creatorUsername]);
   }
   UI::add('hashlists', $hashlists);
   UI::add('numHashlists', sizeof($hashlists));

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -732,7 +732,7 @@ class HashlistUtils {
     }
     
     Factory::getAgentFactory()->getDB()->beginTransaction();
-    $hashlist = new Hashlist(null, $name, $format, $hashtype, 0, $separator, 0, $secret, $hexsalted, $salted, $accessGroup->getId(), '', $brainId, $brainFeatures);
+    $hashlist = new Hashlist(null, $name, $format, $hashtype, 0, $separator, 0, $secret, $hexsalted, $salted, $accessGroup->getId(), '', $brainId, $brainFeatures, $user->getId());
     $hashlist = Factory::getHashlistFactory()->save($hashlist);
     
     $dataSource = "";

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -272,7 +272,8 @@ CREATE TABLE `Hashlist` (
   `accessGroupId` INT(11)      NOT NULL,
   `notes`         TEXT         NOT NULL,
   `brainId`       INT(11)      NOT NULL,
-  `brainFeatures` TINYINT(4)   NOT NULL
+  `brainFeatures` TINYINT(4)   NOT NULL,
+  `creatorId`     INT(11)      NOT NULL
 ) ENGINE = InnoDB;
 
 CREATE TABLE `HashlistHashlist` (

--- a/src/templates/hashlists/index.template.html
+++ b/src/templates/hashlists/index.template.html
@@ -15,6 +15,7 @@
           <th>Hash type</th>
           <th>Format</th>
           <th>Cracked</th>
+		  <th>Created By</th>
           <th>Pre-cracked</th>
           <th>Action</th>
         </tr>
@@ -50,6 +51,11 @@
 						    [[entry.getVal('hashlist').getHashCount()]])
 					    {{ENDIF}}
 				    </td>
+					<td>
+						{{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_HASHES_ACCESS]])]]}}
+							[[entry.getVal('creator')]]
+					    {{ENDIF}}
+					</td>
 				    <td>
 					    {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_HASHLIST_ACCESS]])]] && [[accessControl.hasPermission([[$DAccessControl::ADD_FILE_ACCESS]])]]}}
 						    <form class="float-right mx-1" action="hashlists.php" method="POST">
@@ -88,8 +94,8 @@
           pageLength: 50,
           "order": [ [0, 'asc'] ],
           "columnDefs": [
-            { "orderable": false, "targets": [5, 6] },
-            { "orderable": true, "targets": [0, 1, 2, 3, 4] }
+            { "orderable": false, "targets": [6, 7] },
+            { "orderable": true, "targets": [0, 1, 2, 3, 4, 5] }
           ]
         });
       });


### PR DESCRIPTION
As a group of people using the tool we always wondered where to see which user created the hashlist in order to provide support or give advice.
I thought I would try my best in order to add the feature through a pull request.

For now it is only shown in the "Hashlists" overview as a sortable column.
As so far the ID of the creating user has not been saved with the hashlist, I created the column in the database setup file.

I have no experience with the database migration scripts so please help me out here, thank you. :)

I hope everything is in the right spot and the solution to pass the creator username into the template is done in the right way.
Please let me know as I am always open for improvements.

Thank you for the great tool!