### PR TITLE
Add queryFilter to tasks for only showing assignable agents for hashlists with specific AccessGroups

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -28,6 +28,7 @@
 - Fixed sending two to headers when sending emails (issue #751).
 - Fixed access group not being changed on Hashlist detailed screen (issue #765).
 - Fixed missing check on permissions for sending notifications (issue #757).
+- Fixed unassignable agents are shown as assignable (issue #777).
 
 ## Enhancements
 

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -1,5 +1,6 @@
 <?php
 
+use DBA\AccessGroupAgent;
 use DBA\Agent;
 use DBA\Assignment;
 use DBA\Chunk;
@@ -183,7 +184,9 @@ if (isset($_GET['id'])) {
   UI::add('agentsSpeed', $agentsSpeed);
   
   $assignAgents = array();
-  $allAgents = Factory::getAgentFactory()->filter([]);
+  $qF = new QueryFilter(AccessGroupAgent::ACCESS_GROUP_ID, $hashlist->getAccessGroupId(), "=");
+  $jF = new JoinFilter(Factory::getAccessGroupAgentFactory(), AccessGroupAgent::AGENT_ID, Agent::AGENT_ID);
+  $allAgents = Factory::getAgentFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF])[Factory::getAgentFactory()->getModelName()];
   foreach ($allAgents as $agent) {
     if (!in_array($agent->getId(), $assignedAgents)) {
       $assignAgents[] = $agent;


### PR DESCRIPTION
Closes #777 .

In my environment i have 2 Access Groups. `Default` has no Agent, `restricted` has one Agent. There are also 2 Hashlists and 2 Tasks for each AccessGroup respectively. Here is the List of the assignable Agents for each Task:

In this Task it is expected that 1 Agent is shown since the linked hashlist uses the `restricted` Access Group with the one Agent.
![restricted task one agent](https://user-images.githubusercontent.com/18482238/173164195-1ee06fb8-99e6-4f5c-9448-521c92d7366d.png)

In this Task it is expected that no Agent is shown since the linked hashlist uses the `Default` Access Group with no Agent inside.
![default task no agent](https://user-images.githubusercontent.com/18482238/173164248-51d7a3a0-2514-4ea9-8529-85153bed54c9.png)

