### PR TITLE
Add automated testing workflow for GitHub (and other minor improvements)

### DIFF
--- a/.github/scripts/await-hashtopolis-startup.sh
+++ b/.github/scripts/await-hashtopolis-startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+COUNT=0
+while [ $COUNT -lt 16 ]
+do
+  curl localhost:8080/api/server.php -X POST -H 'Content-Type: application/json' -d '{ "action": "testConnection" }' | grep SUCCESS
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
+  COUNT=$[$COUNT+1]
+  sleep 4
+done
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Hashtopolis
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Start application containers
+        working-directory: .devcontainer
+        run: docker compose up -d
+      - name: Wait until entrypoint is finished and Hashtopolis is started
+        run: bash .github/scripts/await-hashtopolis-startup.sh
+      - name: Give Apache permissions on necessary directories # for the tests, only src/files and src/inc/utils/locks seem necessary
+        run: docker exec hashtopolis chown -R www-data:www-data /var/www/html/src
+      - name: Run test suite
+        run: docker exec hashtopolis php ci/run.php -vmaster

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ query.log
 *.iml
 src/files/*
 !src/files/.htaccess
+/ci/db-backups/
 .vs/
 *.phpproj
 *.sln

--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -13,7 +13,9 @@ abstract class HashtopolisTest {
   
   protected static $status    = 0;
   protected static $testCount = 0;
-  
+ 
+  protected static $failed = array();
+
   protected $user;
   protected $apiKey;
   
@@ -39,7 +41,7 @@ abstract class HashtopolisTest {
     $this->init($fromVersion);
     
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running upgrades...");
-    include("/var/www/html/hashtopolis/src/install/updates/update.php");
+    include(dirname(__FILE__) ."/../src/install/updates/update.php");
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Initialization with upgrade done!");
   }
   
@@ -67,7 +69,7 @@ abstract class HashtopolisTest {
     
     // load DB
     if ($version == "master") {
-      Factory::getAgentFactory()->getDB()->query(file_get_contents("/var/www/html/hashtopolis/src/install/hashtopolis.sql"));
+      Factory::getAgentFactory()->getDB()->query(file_get_contents(dirname(__FILE__) ."/../src/install/hashtopolis.sql"));
     }
     else {
       Factory::getAgentFactory()->getDB()->query(file_get_contents(dirname(__FILE__) . "/files/db_" . $version . ".sql"));
@@ -77,7 +79,6 @@ abstract class HashtopolisTest {
     
     // insert user and api key
     $salt = Util::randomString(30);
-    $PEPPER = ["abcd", "bcde", "cdef", "aaaa"];
     $hash = Encryption::passwordHash(HashtopolisTest::USER_PASS, $salt);
     $this->user = new User(null, 'testuser', '', $hash, $salt, 1, 0, 0, 0, 3600, AccessUtils::getOrCreateDefaultAccessGroup()->getId(), 0, '', '', '', '');
     $this->user = Factory::getUserFactory()->save($this->user);
@@ -99,6 +100,8 @@ abstract class HashtopolisTest {
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Test '$test' failed: $error");
     self::$testCount++;
     self::$status = -1;
+
+    self::$failed[] = $test; 
   }
   
   public function validState($response, $assert) {
@@ -118,7 +121,19 @@ abstract class HashtopolisTest {
   public static function getTestCount() {
     return self::$testCount;
   }
+
+  public static function getTestsPassedCount() {
+    return self::$testCount - count(self::$failed);
+  }
   
+  public static function getTestsFailedCount() {
+    return count(self::$failed);
+  }
+
+  public static function getFailedTests() {
+    return self::$failed;
+  }
+ 
   protected function testSuccess($test) {
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Test '$test' passed!");
     self::$testCount++;
@@ -134,5 +149,55 @@ abstract class HashtopolisTest {
   
   public function getRunType() {
     return $this->runType;
+  }
+
+  protected function deleteTaskIfExists($name){
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "task",
+      "request" => "listTasks",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+
+    foreach ($response["tasks"] as $task) {
+      if ($task["name"] == $name) {
+        $response = HashtopolisTestFramework::doRequest([
+          "section" => "task",
+          "request" => "deleteTask",
+          "taskId" => $task["taskId"],
+          "accessKey" => "mykey"
+          ], HashtopolisTestFramework::REQUEST_UAPI
+          );
+          if ($response === false) {
+            return false;
+          }
+        }
+    }
+    return true;
+  }
+
+  protected function deleteFileIfExists($name) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "file",
+      "request" => "listFiles",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+
+    foreach ($response["files"] as $file) {
+      if ($file["filename"] == $name) {
+        $response = HashtopolisTestFramework::doRequest([
+          "section" => "file",
+          "request" => "deleteFile",
+          "fileId" => $file["fileId"],
+          "accessKey" => "mykey"
+        ], HashtopolisTestFramework::REQUEST_UAPI
+        );
+        if ($response === false) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 }

--- a/ci/HashtopolisTestFramework.class.php
+++ b/ci/HashtopolisTestFramework.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use DBA\Factory;
+
 class HashtopolisTestFramework {
   const REQUEST_CLIENT = 0;
   const REQUEST_UAPI   = 1;
@@ -9,7 +11,9 @@ class HashtopolisTestFramework {
    */
   private static $instances = [];
   public static  $logLevel  = HashtopolisTestFramework::LOG_INFO;
-  
+
+  private $dbBackupFile;
+
   public static function register($test) {
     self::$instances[] = $test;
   }
@@ -20,43 +24,101 @@ class HashtopolisTestFramework {
   
   /**
    * @param string $version
+   * @param string [] $testNames
    * @param int $runType
    * @return int
    */
-  public function execute($version, $runType) {
-    foreach (self::$instances as $instance) {
-      if ($version != 'master' && (Util::versionComparison($version, $instance->getMinVersion()) > 0 || $instance->getMinVersion() == 'master')) {
-        echo "Ignoring " . $instance->getTestName() . ": minimum " . $instance->getMinVersion() . " required, but testing $version...\n";
-        continue;
+  public function execute($version, $testNames, $runType) {
+    try {
+      $this->backupDatabase();
+
+      foreach (self::$instances as $instance) {
+        if ($this-> isTestIncluded($instance, $version, $testNames, $runType, false)) {
+          $instance->init($version);
+          $instance->run();
+        }
       }
-      else if ($instance->getMaxVersion() != 'master' && (Util::versionComparison($version, $instance->getMaxVersion()) < 0 || $version == 'master')) {
-        echo "Ignoring " . $instance->getTestName() . ": maximum " . $instance->getMaxVersion() . " required, but testing $version...\n";
-        continue;
-      }
-      else if ($runType > $instance->getRunType()) {
-        continue;
-      }
-      $instance->init($version);
-      $instance->run();
+    }
+    finally {
+      $this->restoreDatabase();
     }
     return HashtopolisTest::getStatus();
-  }
-  
-  public function executeWithUpgrade($fromVersion, $runType) {
-    foreach (self::$instances as $instance) {
-      if ($instance->getMaxVersion() != 'master') {
-        echo "Ignoring " . $instance->getTestName() . ": maximum " . $instance->getMaxVersion() . " required, but testing master...\n";
-        continue;
+ }
+
+  public function executeWithUpgrade($fromVersion, $testNames, $runType) {
+    try {
+      $this->backupDatabase();
+
+      foreach (self::$instances as $instance) {
+        if ($this-> isTestIncluded($instance, $fromVersion, $testNames, $runType, true)) {
+          $instance->initAndUpgrade($fromVersion);
+          $instance->run();
+        }
       }
-      else if ($runType > $instance->getRunType()) {
-        continue;
-      }
-      $instance->initAndUpgrade($fromVersion);
-      $instance->run();
+    }
+    finally {
+      $this->restoreDatabase();
     }
     return HashtopolisTest::getStatus();
+}
+
+private function backupDatabase() {
+  global $CONN;
+
+  if (!file_exists(dirname(__FILE__) . "/../ci/db-backups")) {
+    mkdir(dirname(__FILE__) . "/../ci/db-backups");
   }
-  
+
+  $this->dbBackupFile = dirname(__FILE__) . "/../ci/db-backups/database_backup_" . date('Y_m_d-H_i_s').  ".sql";
+  HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Backup database to " . $this->dbBackupFile . "...");
+
+  // Note that the '-y' option avoids requirement on 'PROCESS' privilege for the 'hashtopolis' user!
+  exec("mysqldump hashtopolis -y -h".$CONN['server'] . " -P".$CONN['port'] . " -u".$CONN['user'] . " -p".$CONN['pass'] ." > " . $this->dbBackupFile, $output, $status);
+  if ($status != 0) {
+    $this->dbBackupFile = "";
+
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Database backup failed.");
+    die("test aborted!\n");
+  }
+}
+
+private function restoreDatabase() {
+  global $CONN;
+
+  if (!empty($this->dbBackupFile)) {
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Restoring database from " . $this->dbBackupFile . "...");
+
+    // drop old data
+    Factory::getAgentFactory()->getDB()->query("DROP DATABASE IF EXISTS hashtopolis");
+    Factory::getAgentFactory()->getDB()->query("CREATE DATABASE hashtopolis");
+    Factory::getAgentFactory()->getDB()->query("USE hashtopolis");
+
+    // restore original DB
+    Factory::getAgentFactory()->getDB()->query(file_get_contents($this->dbBackupFile));
+
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Database successfully restored!" . $this->dbBackupFile . "...");
+  }
+}
+
+private function isTestIncluded($instance, $version, $testNames, $runType, $upgrade) {
+  if (!empty($testNames) && !in_array(get_class($instance), $testNames)) {
+    return false;
+  }
+  if (!$upgrade && $version != 'master' && (Util::versionComparison($version, $instance->getMinVersion()) > 0 || $instance->getMinVersion() == 'master')) {
+    echo "Ignoring " . $instance->getTestName() . ": minimum " . $instance->getMinVersion() . " required, but testing $version...\n";
+    return false;
+  }
+  if ($instance->getMaxVersion() != 'master' && (Util::versionComparison($version, $instance->getMaxVersion()) < 0 || $version == 'master')) { 
+    echo "Ignoring " . $instance->getTestName() . ": maximum " . $instance->getMaxVersion() . " required, but testing $version...\n";
+    return false;
+  }
+  if ($runType > $instance->getRunType()) {
+    return false;
+  }
+
+  return true;
+}
+
   /**
    * @param array $request
    * @param int $requestType
@@ -113,5 +175,20 @@ class HashtopolisTestFramework {
         break;
     }
     echo "[" . date("d.m.Y - H:i:s") . "][" . $lvl . "]: " . $message . "\n";
+  }
+
+  public static function reportTestSummary() { 
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, " --Test Report-- ");
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Total Test Count : " . HashtopolisTest::getTestCount());
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Tests Passed : " . HashtopolisTest::getTestsPassedCount());
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Tests Failed : " . HashtopolisTest::getTestsFailedCount());
+  
+    $failedTests = HashtopolisTest::getFailedTests();
+    if (!empty($failedTests)) {  
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Failed Tests:");
+      foreach ($failedTests as &$value) {
+        HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, " " . $value);
+      }
+    }
   }
 }

--- a/ci/run.php
+++ b/ci/run.php
@@ -4,16 +4,10 @@
  * This is the entry point to run the full environment
  */
 
-$CONN = [
-  "db" => "hashtopolis",
-  "server" => "localhost",
-  "user" => "root",
-  "pass" => "",
-  "port" => 3306
-];
-require_once("/var/www/html/hashtopolis/src/dba/init.php");
-require_once("/var/www/html/hashtopolis/src/inc/defines/config.php");
-require_once("/var/www/html/hashtopolis/src/inc/info.php");
+require_once(dirname(__FILE__) . "/../src/inc/conf.php");
+require_once(dirname(__FILE__) . "/../src/dba/init.php");
+require_once(dirname(__FILE__) . "/../src/inc/defines/config.php");
+require_once(dirname(__FILE__) . "/../src/inc/info.php");
 require_once(dirname(__FILE__) . "/../src/inc/Util.class.php");
 require_once(dirname(__FILE__) . "/../src/inc/Encryption.class.php");
 require_once(dirname(__FILE__) . "/../src/inc/utils/AccessUtils.class.php");
@@ -35,20 +29,41 @@ foreach ($dir as $entry) {
 
 $TEST = true;
 
-if (sizeof($argv) < 2) {
-  die("Invalid number of arguments!\nphp -f run.php <version> [upgrade]\n");
+// determine the version, upgrade and which tests to run
+$options = getopt("v:t::u::");
+
+if (empty($options["v"])) {
+  HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "No version specified! \nphp -f run.php -v <version> [-t <tests> ] [-u <upgrade> ]");
+  die();
 }
-$version = $argv[1];
+
+$version = $options["v"];
+
+if (empty($options["t"])) {
+  HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running all tests");
+  $testNames = [];
+}
+else {
+  $testNames = explode(",", $options["t"]);
+}
+
+if (empty($options["u"])) {
+  HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "No upgrade selected");
+}
+else {
+  $upgrade = $options["u"];
+}
+
 HashtopolisTestFramework::$logLevel = HashtopolisTestFramework::LOG_DEBUG;
 
 $framework = new HashtopolisTestFramework();
-if (isset($argv[2]) && $argv[2] != 'master') {
-  $returnStatus = $framework->executeWithUpgrade($argv[2], HashtopolisTest::RUN_FULL);
+if (isset($upgrade) && $upgrade != 'master') {
+  $returnStatus = $framework->executeWithUpgrade($upgrade, $testNames, HashtopolisTest::RUN_FULL);
 }
 else {
-  $returnStatus = $framework->execute($version, HashtopolisTest::RUN_FULL);
+  $returnStatus = $framework->execute($version, $testNames, HashtopolisTest::RUN_FULL);
 }
 
-HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, HashtopolisTest::getTestCount() . " tests executed");
+HashtopolisTestFramework::reportTestSummary();
 
 exit($returnStatus);

--- a/ci/tests/TaskTest.class.php
+++ b/ci/tests/TaskTest.class.php
@@ -24,12 +24,32 @@ class TaskTest extends HashtopolisTest {
     }
   }
   
+  private function cleanup() {
+    $status = true;
+    // delete the created task
+    $status &= $this->deleteTaskIfExists("Test Task");
+
+    // remove the added files
+    $status &= $this->deleteFileIfExists("example.dict");
+    $status &= $this->deleteFileIfExists("best64.rule");
+
+    if (!$status) {
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Some cleanup failed, deleting task or deleting files not succesful!");
+    }
+  }
+
   public function run() {
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running " . $this->getTestName() . "...");
     $this->prepare();
-    $this->testListTasks();
-    $this->testCreateTask(["name" => "Test Task", "hashlistId" => 1, "attackCmd" => "#HL# -a 0 -r best64.rule example.dict", "priority" => 1, "color" => "5D5D5D", "crackerVersionId" => 1, "files" => [1, 2]]);
-    $this->testListTasks(['Test Task']);
+    try { 
+      $this->testListTasks();
+      $this->testCreateTask(["name" => "Test Task", "hashlistId" => 1, "attackCmd" => "#HL# -a 0 -r best64.rule example.dict", "priority" => 1, "color" => "5D5D5D", "crackerVersionId" => 1, "files" => [1, 2]]);
+      $this->testListTasks(['Test Task']);
+    }
+    finally {
+      $this->cleanup();
+    }
+
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, $this->getTestName() . " completed");
   }
   
@@ -148,10 +168,9 @@ class TaskTest extends HashtopolisTest {
     }
     return true;
   }
-  
+
   public function getTestName() {
     return "Task Test";
   }
 }
-
 HashtopolisTestFramework::register(new TaskTest());

--- a/ci/tests/integration/MaxAgentsTest.class.php
+++ b/ci/tests/integration/MaxAgentsTest.class.php
@@ -21,10 +21,30 @@ class MaxAgentsTest extends HashtopolisTest {
     }
   }
 
+  private function cleanup() {
+    $status = true;
+    // delete the created tasks
+    $status &= $this->deleteTaskIfExists("task-1");
+    $status &= $this->deleteTaskIfExists("task-2");
+
+    // remove the added files
+    $status &= $this->deleteFileIfExists("example.dict");
+    $status &= $this->deleteFileIfExists("best64.rule");
+
+    if (!$status) {
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Some cleanup failed, deleting task or deleting files not succesful!");
+    }
+  }
+
   public function run() {
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running " . $this->getTestName() . "...");
     $this->prepare();
-    $this->testMaxAgents();
+    try {
+      $this->testMaxAgents();
+    }
+    finally {
+      $this->cleanup();
+    }
     HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, $this->getTestName() . " completed");
   }
 


### PR DESCRIPTION
This PR contains a new workflow which allows Hashtopolis to be automatically tested on GitHub. 

We have also fixed the tests which currently fail and added a couple of minor usability improvements, such as: backing up the database before running the test suite, printing the amount of succeeded and failed tests and the possibility to run only a subset. 

For example:
```
~/html/ci$ php run.php
php -f run.php -v <version> [-t <tests> ] [-u <upgrade> ]

$ php run.php -vmaster -tTaskTest
[16.06.2022 - 14:36:35][INFO ]: No upgrade selected
[16.06.2022 - 14:36:35][INFO ]: Backup database to /var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_36_35.sql...
[16.06.2022 - 14:36:35][INFO ]: Initializing Task Test...
[16.06.2022 - 14:36:40][INFO ]: Running Task Test...
[16.06.2022 - 14:36:40][DEBUG]: http://localhost/api/user.php <- {"section":"file","request":"addFile","filename":"example.dict","fileType":0,"source":"inline","data":"MAowMAowMDAKMDAwMAowMDAwMAowMDAwMDAKMDAwMDAwMAowMDAwMDAwMAowMDAwMDAwMDAKMDAwMDAwMDAwMAowMDAwMDAwMDkKMDAwMDAwMDEKMDAwMDAwMDExCjAwMDAwMDE5NzYKMDAwMDAwMjQyNwowMDAwMDA0MAowMDAwMDA3CjAwMDAwMQowMDAwMDE4OAowMDAwMDE5CjAwMDAwNwowMDAwMHgKMDAwMDEKMDAwMDEwODAKMDAwMDExMTEKMDAwMDEyMzQKMDAwMDE0NzgKMDAwMDE5NjkKMDAwMDIyCjAwMDAzNzEyCjAwMDA1CjAwMDA1MAowMDAwNgowMDAwNwowMDAwOTA5MAowMDAwOTExMQowMDAwOTcxNQowMDAwcXcKM
[16.06.2022 - 14:36:40][DEBUG]: http://localhost/api/user.php -> {"section":"file","request":"addFile","response":"OK"}
...
[16.06.2022 - 14:36:41][INFO ]: Task Test completed
[16.06.2022 - 14:36:41][INFO ]: Restoring database from /var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_36_35.sql...
[16.06.2022 - 14:36:41][INFO ]: Database successfully restored!/var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_36_35.sql...
[16.06.2022 - 14:36:41][INFO ]:  --Test Report-- 
[16.06.2022 - 14:36:41][INFO ]: Total Test Count : 3
[16.06.2022 - 14:36:41][INFO ]: Tests Passed : 3
[16.06.2022 - 14:36:41][INFO ]: Tests Failed : 0

~/html/ci$ php run.php -vmaster 
[16.06.2022 - 14:53:19][INFO ]: Running all tests
[16.06.2022 - 14:53:19][INFO ]: No upgrade selected
[16.06.2022 - 14:53:19][INFO ]: Backup database to /var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_53_19.sql...
[16.06.2022 - 14:53:19][INFO ]: Initializing Account Test...
[16.06.2022 - 14:53:24][INFO ]: Running Account Test...
[16.06.2022 - 14:53:24][DEBUG]: http://localhost/api/user.php <- {"section":"account","request":"getInformation","accessKey":"mykey"}
[16.06.2022 - 14:53:24][DEBUG]: http://localhost/api/user.php -> {"section":"account","request":"getInformation","response":"OK","userId":1,"email":"","rightGroupId":1,"sessionLength":3600}
...
[16.06.2022 - 14:54:28][INFO ]: Max Agents Test completed
[16.06.2022 - 14:54:28][INFO ]: Restoring database from /var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_53_19.sql...
[16.06.2022 - 14:54:28][INFO ]: Database successfully restored!/var/www/html/ci/../ci/db-backups/database_backup_2022_06_16-14_53_19.sql...
[16.06.2022 - 14:54:28][INFO ]:  --Test Report-- 
[16.06.2022 - 14:54:28][INFO ]: Total Test Count : 204
[16.06.2022 - 14:54:28][INFO ]: Tests Passed : 204
[16.06.2022 - 14:54:28][INFO ]: Tests Failed : 0
