### PR TITLE
Failed to delete hashlist containing cracked hashes while agent is running on the hashlist

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -28,6 +28,7 @@
 - Fixed sending two to headers when sending emails (issue #751).
 - Fixed access group not being changed on Hashlist detailed screen (issue #765).
 - Fixed missing check on permissions for sending notifications (issue #757).
+- Fixed not deleting all references (related to zaps) when deleting hashlist (issue #747).
 
 ## Enhancements
 

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -18,6 +18,7 @@ use DBA\Assignment;
 use DBA\Chunk;
 use DBA\AgentError;
 use DBA\Zap;
+use DBA\AgentZap;
 use DBA\Factory;
 use DBA\Speed;
 
@@ -507,10 +508,16 @@ class HashlistUtils {
         $toDelete[] = $superHashlist;
       }
     }
-    Factory::getHashlistHashlistFactory()->massDeletion([Factory::FILTER => $qF]);
-    
+
+    // when we delete all zaps, we have to make sure that from agentZap, there are no references to zaps of this hashlist
     $qF = new QueryFilter(Zap::HASHLIST_ID, $hashlist->getId(), "=");
+    $zapIds = Util::arrayOfIds(Factory::getAgentZapFactory()->filter([Factory::FILTER => $qF]));
+    $qF1 = new ContainFilter(AgentZap::LAST_ZAP_ID, $zapIds);
+    $uS = new UpdateSet(AgentZap::LAST_ZAP_ID, null);
+    Factory::getAgentZapFactory()->massUpdate([Factory::UPDATE => $uS, Factory::FILTER => $qF1]);
     Factory::getZapFactory()->massDeletion([Factory::FILTER => $qF]);
+
+    Factory::getHashlistHashlistFactory()->massDeletion([Factory::FILTER => $qF]);
     
     $payload = new DataSet(array(DPayloadKeys::HASHLIST => $hashlist));
     NotificationHandler::checkNotifications(DNotificationType::DELETE_HASHLIST, $payload);

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -511,7 +511,7 @@ class HashlistUtils {
 
     // when we delete all zaps, we have to make sure that from agentZap, there are no references to zaps of this hashlist
     $qF = new QueryFilter(Zap::HASHLIST_ID, $hashlist->getId(), "=");
-    $zapIds = Util::arrayOfIds(Factory::getAgentZapFactory()->filter([Factory::FILTER => $qF]));
+    $zapIds = Util::arrayOfIds(Factory::getZapFactory()->filter([Factory::FILTER => $qF]));
     $qF1 = new ContainFilter(AgentZap::LAST_ZAP_ID, $zapIds);
     $uS = new UpdateSet(AgentZap::LAST_ZAP_ID, null);
     Factory::getAgentZapFactory()->massUpdate([Factory::UPDATE => $uS, Factory::FILTER => $qF1]);
@@ -521,7 +521,7 @@ class HashlistUtils {
     
     $payload = new DataSet(array(DPayloadKeys::HASHLIST => $hashlist));
     NotificationHandler::checkNotifications(DNotificationType::DELETE_HASHLIST, $payload);
-    
+
     $qF = new QueryFilter(NotificationSetting::OBJECT_ID, $hashlist->getId(), "=");
     $notifications = Factory::getNotificationSettingFactory()->filter([Factory::FILTER => $qF]);
     foreach ($notifications as $notification) {


### PR DESCRIPTION
I was able to reproduce it:

-     Create a hashlist with multiple hashes
-     Create a task
-     Upload one crack for one of the hashes
-     While task is running, delete the task
-     Delete the hashlist boom