### PR TITLE
added gd dependency for php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-RUN set -ex && docker-php-ext-install pdo_mysql 
+RUN apt-get update && apt-get install -y libpng-dev
+
+RUN set -ex && docker-php-ext-install pdo_mysql gd
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 


### PR DESCRIPTION
added gd php extension, libpng-dev is required to build the extension.

closes issue #796 