### PR TITLE
Docker build include git commit if possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ COPY LICENSE.txt HEAD* /var/www/.git/
 
 RUN rm /var/www/.git/LICENSE.txt
 
+RUN sed -i 's/KeepAliveTimeout 5/KeepAliveTimeout 10/' /etc/apache2/apache2.conf
+
 COPY --chown=www-data:www-data ./src/ /var/www/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,12 @@ RUN { \
     echo "max_execution_time = 60"; \
 } > "$PHP_INI_DIR/conf.d/custom.ini"
 
+# workaround for the copy of git HEAD, as when called without ./build.sh, this file does not exist
+
+RUN mkdir -p /var/www/.git
+
+COPY LICENSE.txt HEAD* /var/www/.git/
+
+RUN rm /var/www/.git/LICENSE.txt
+
 COPY --chown=www-data:www-data ./src/ /var/www/html/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+git rev-parse --short HEAD > HEAD
+
+docker build -t hashtopolis-server .
+
+rm HEAD


### PR DESCRIPTION
When building a docker image for Hashtopolis, there will be an issue when the image later is updated and the container restarted. In such a case Hashtopolis is not able to figure out, that it was updated, as the build information remains set to `repository`.

In order to allow building docker containers which can later be updated and Hashtopolis being able to apply upgrades, it must include the git commit hash somewhere. This can be achieved by running `./build.sh` which will place the hash into a file which is then included in the docker build process.