### PR TITLE
Update hashtopolis.sql to fix yubikey_url.

### DIFF
--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -124,7 +124,7 @@ INSERT INTO `Config` (`configId`, `configSectionId`, `item`, `value`) VALUES
   (16, 3, 'batchSize', '50000'),
   (18, 2, 'yubikey_id', ''),
   (19, 2, 'yubikey_key', ''),
-  (20, 2, 'yubikey_url', 'http://api.yubico.com/wsapi/2.0/verify'),
+  (20, 2, 'yubikey_url', 'https://api.yubico.com/wsapi/2.0/verify'),
   (22, 3, 'pagingSize', '5000'),
   (23, 3, 'plainTextMaxLength', '200'),
   (24, 3, 'hashMaxLength', '1024'),


### PR DESCRIPTION
The default yubikey_url for new installations was being set to a HTTP endpoint that has been deprecated by Yubikey. There was a previous migration from v0.3.2->v0.4.0 that updated this to HTTPS, but the new installer was never moved to HTTPS. This PR corrects the issue to allow the Yubikey integration to work out of the box. 