### PR TITLE
Added missing descriptions for user api commands

### DIFF
--- a/src/inc/defines/userApi.php
+++ b/src/inc/defines/userApi.php
@@ -587,6 +587,8 @@ class USectionAgent extends UApi {
         return "Set how errors from an agent should be handled";
       case USectionAgent::SET_TRUSTED:
         return "Set if an agent is trusted or not";
+      case USectionAgent::DELETE_AGENT:
+        return "Delete agents";
       default:
         return "__" . $constant . "__";
     }
@@ -672,6 +674,10 @@ class USectionTask extends UApi {
         return "Archive supertasks";
       case USectionTask::GET_CRACKED:
         return "Retrieve all cracked hashes by a task";
+      case USectionTask::SET_TASK_MAX_AGENTS:
+        return "Set max agents for tasks";
+      case USectionTask::TASK_ASSIGN_AGENT:
+        return "Assign agents to a task";
       default:
         return "__" . $constant . "__";
     }
@@ -714,6 +720,8 @@ class USectionPretask extends UApi {
         return "Set if a preconfigured task is small or not";
       case USectionPretask::DELETE_PRETASK:
         return "Delete preconfigured tasks";
+      case USectionPretask::SET_PRETASK_MAX_AGENTS:
+        return "Set max agents for a preconfigured task";
       default:
         return "__" . $constant . "__";
     }


### PR DESCRIPTION
Some descriptions were not added and were showing up as __<id>__ instead of a readable text.