### PR TITLE
only allow setting the flag to not cpu only on agent update when it is not set already (during registration)

### DIFF
--- a/src/inc/api/APIUpdateClientInformation.class.php
+++ b/src/inc/api/APIUpdateClientInformation.class.php
@@ -25,7 +25,7 @@ class APIUpdateClientInformation extends APIBasic {
     }
     
     // save agent details
-    if (strlen($this->agent->getUid()) == 0) {
+    if (strlen($this->agent->getUid()) == 0 && $this->agent->getCpuOnly() == 0) {
       // we only update this variable on the first time, otherwise we would overwrite manual changes
       Factory::getAgentFactory()->set($this->agent, Agent::CPU_ONLY, $cpuOnly);
     }


### PR DESCRIPTION
When registering an agent with --cpu-only, in case the CPU is from AMD, on the first client update, the flag gets set back to non-cpu-only. 
This fix catches this case and does not allow to unset the flag again.