### PR TITLE
Adding user and post command for dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,13 @@
 FROM php:8-apache  
 
-ARG DEV_CONTAINER_USER_CMD
+ARG DEV_CONTAINER_USER_CMD_PRE
+ARG DEV_CONTAINER_USER_CMD_POST
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
-RUN if [ -n "${DEV_CONTAINER_USER_CMD}" ]; then echo "${DEV_CONTAINER_USER_CMD}" | sh ; fi
+RUN if [ -n "${DEV_CONTAINER_USER_CMD_PRE}" ]; then echo "${DEV_CONTAINER_USER_CMD_PRE}" | sh ; fi
 
 # Configure apt and install packages
 RUN apt-get update \
@@ -49,6 +50,11 @@ RUN rm -rf /etc/apache2/sites-enabled \
 RUN groupadd vscode && useradd -rm -d /var/www -s /bin/bash -g vscode -G www-data -u 1001 vscode \
     && chown -R www-data:www-data /var/www \
     && chmod g+w /var/www
+
+# Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
+RUN if [ -n "${DEV_CONTAINER_USER_CMD_POST}" ]; then echo "${DEV_CONTAINER_USER_CMD_POST}" | sh ; fi
+
+# Switching to vscode user and working dir
 WORKDIR /var/www
 USER vscode
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
 		"xdebug.php-debug",
 		"bmewburn.vscode-intelephense-client",
 		"editorconfig.editorconfig",
+		"zobo.php-intellisense",
 	],
 	"remoteUser": "vscode",
 	"settings": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - DEV_CONTAINER_USER_CMD
+        - DEV_CONTAINER_USER_CMD_PRE
+        - DEV_CONTAINER_USER_CMD_POST
     depends_on:
       - db
     ports:


### PR DESCRIPTION
Changing parameter

DEV_CONTAINER_USER_CMD

To two new parameters:

DEV_CONTAINER_USER_CMD_PRE
DEV_CONTAINER_USER_CMD_POST

This allows for customization and the start and at the end of the dev container.
Also adding php extension to the dev-container.
