### PR TITLE
Remove duplicated extension in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
 		"xdebug.php-debug",
 		"bmewburn.vscode-intelephense-client",
 		"editorconfig.editorconfig",
-		"zobo.php-intellisense",
 	],
 	"remoteUser": "vscode",
 	"settings": {


### PR DESCRIPTION
Apparently I screwed up and added a vscode extension for php while this already was inside the devcontainer config, removed the duplicated.