### PR TITLE
Force devcontainer nodejs to use OpenSSL CA

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ ARG DEV_CONTAINER_USER_CMD_POST
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_OPTIONS='--use-openssl-ca'
 
 # Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
 RUN if [ -n "${DEV_CONTAINER_USER_CMD_PRE}" ]; then echo "${DEV_CONTAINER_USER_CMD_PRE}" | sh ; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,10 @@
 		"xdebug.php-debug",
 		"bmewburn.vscode-intelephense-client",
 		"editorconfig.editorconfig",
-		"zobo.php-intellisense",
 	],
+	"remoteEnv": {
+		"NODE_OPTIONS": "--use-openssl-ca",
+	},
 	"remoteUser": "vscode",
 	"settings": {
 		"terminal.integrated.profiles.linux":{


### PR DESCRIPTION
When using the dev container in some environments where enterprise or other custom root ca's are using for for example TLS proxies. Vscode does not install extensions automatically. 

This fix forces the devcontainer to use the OpenSSL CA chain. Next you can use the DEV_CONTAINER_USER_CMD_PRE to inject your custom ca certificate.