### PR TITLE
when a pretask is removed from a supertask it should be deleted in the case it was created by an import

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,7 +2,7 @@
 
 ## Bugfixes
 
-- When a preconfigured task is removed from a supertask and its originating from an import, it should be deleted (issue #865).
+- When deleting a supertask that was created from an import, pretasks that were removed from this supertask should also be deleted (issue #865).
 
 # v0.12.0 -> v0.13.0
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,9 @@
+# v0.13.0 -> v0.x.x
+
+## Bugfixes
+
+- When a preconfigured task is removed from a supertask and its originating from an import, it should be deleted (issue #865).
+
 # v0.12.0 -> v0.13.0
 
 ## Features

--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -486,6 +486,12 @@ class SupertaskUtils {
     $qF2 = new QueryFilter(SupertaskPretask::PRETASK_ID, $pretaskId, "=");
     $supertaskPretask = Factory::getSupertaskPretaskFactory()->filter([Factory::FILTER => [$qF1, $qF2]], true);
     Factory::getSupertaskPretaskFactory()->delete($supertaskPretask);
+    
+    // check if the preconfigured task was from an import. in this case also delete it
+    $pretask = PretaskUtils::getPretask($pretaskId);
+    if ($pretask->getIsMaskImport() == 1) {
+      PretaskUtils::deletePretask($pretaskId);
+    }
   }
   
   /**


### PR DESCRIPTION
closes issue #865