### PR TITLE
Internal server error when using the splitrule functionality.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,22 @@
             }
         },
         {
+          "name": "Launch test framework",
+          "type": "php",
+          "request": "launch",
+          "program": "${workspaceFolder}/ci/run.php",
+          "args": ["-v", "master"],
+          // "args": ["-v", "master", "-t", "specifictest"],
+          "port": 0,
+          "runtimeArgs": [
+              "-dxdebug.start_with_request=yes"
+          ],
+          "env": {
+              "XDEBUG_MODE": "debug,develop",
+              "XDEBUG_CONFIG": "client_port=${port}"
+          }
+        },
+        {
             "name": "Launch Built-in web server",
             "type": "php",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,6 @@
 {
     "version": "0.2.0",
+
     "configurations": [
 
         {
@@ -28,8 +29,7 @@
           "type": "php",
           "request": "launch",
           "program": "${workspaceFolder}/ci/run.php",
-          "args": ["-v", "master"],
-          // "args": ["-v", "master", "-t", "specifictest"],
+          "args": ["-v", "master", "-t${input:testToRun}"],
           "port": 0,
           "runtimeArgs": [
               "-dxdebug.start_with_request=yes"
@@ -58,5 +58,12 @@
                 "action": "openExternally"
             }
         }
-    ]
+    ],
+    "inputs": [
+      {
+        "id": "testToRun",
+        "type": "promptString",
+        "description": "Name of test to run, example: MaxAgentsTest. If empty, all tests."
+      }
+    ],
 }

--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -177,6 +177,31 @@ abstract class HashtopolisTest {
     return true;
   }
 
+  protected function deleteHashlistIfExists($name){
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "hashlist",
+      "request" => "listHashlists",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+
+    foreach ($response["hashlists"] as $hashlist) {
+      if ($hashlist["name"] == $name) {
+        $response = HashtopolisTestFramework::doRequest([
+          "section" => "hashlist",
+          "request" => "deleteHashlist",
+          "hashlistId" => $hashlist["hashlistId"],
+          "accessKey" => "mykey"
+          ], HashtopolisTestFramework::REQUEST_UAPI
+          );
+          if ($response === false) {
+            return false;
+          }
+        }
+    }
+    return true;
+  }
+
   protected function deleteFileIfExists($name) {
     $response = HashtopolisTestFramework::doRequest([
       "section" => "file",

--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -162,17 +162,27 @@ abstract class HashtopolisTest {
 
     foreach ($response["tasks"] as $task) {
       if ($task["name"] == $name) {
-        $response = HashtopolisTestFramework::doRequest([
-          "section" => "task",
-          "request" => "deleteTask",
-          "taskId" => $task["taskId"],
-          "accessKey" => "mykey"
-          ], HashtopolisTestFramework::REQUEST_UAPI
+        if ($task['type'] == 1) {
+          $response = HashtopolisTestFramework::doRequest([
+            "section" => "task",
+            "request" => "deleteSupertask",
+            "supertaskId" => $task['supertaskId'],
+            "accessKey" => "mykey"
+            ], HashtopolisTestFramework::REQUEST_UAPI
           );
-          if ($response === false) {
-            return false;
-          }
+        } else {
+          $response = HashtopolisTestFramework::doRequest([
+            "section" => "task",
+            "request" => "deleteTask",
+            "taskId" => $task["taskId"],
+            "accessKey" => "mykey"
+            ], HashtopolisTestFramework::REQUEST_UAPI
+          );
         }
+        if ($response === false) {
+          return false;
+        }
+      }
     }
     return true;
   }

--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -87,10 +87,10 @@ abstract class HashtopolisTest {
     Factory::getAccessGroupUserFactory()->save($accessGroup);
     $this->apiKey = new ApiKey(null, 0, time() + 3600, 'mykey', 0, $this->user->getId(), 1);
     $this->apiKey = Factory::getApiKeyFactory()->save($this->apiKey);
-    $versionStore = new StoredValue("version", ($version == 'master') ? explode("+", $VERSION)[0] : $version);
-    Factory::getStoredValueFactory()->save($versionStore);
-    $buildStore = new StoredValue("build", ($version == 'master') ? Util::getGitCommit(true) : $this->RELEASES[$version]);
-    Factory::getStoredValueFactory()->save($buildStore);
+    // $versionStore = new StoredValue("version", ($version == 'master') ? explode("+", $VERSION)[0] : $version);
+    // Factory::getStoredValueFactory()->save($versionStore);
+    // $buildStore = new StoredValue("build", ($version == 'master') ? Util::getGitCommit(true) : $this->RELEASES[$version]);
+    // Factory::getStoredValueFactory()->save($buildStore);
   }
   
   abstract function run();

--- a/ci/tests/integration/RuleSplitTest.class.php
+++ b/ci/tests/integration/RuleSplitTest.class.php
@@ -26,7 +26,7 @@ class RuleSplitTest extends HashtopolisTest {
     $status = true;
     // delete the created tasks
     $status &= $this->deleteTaskIfExists("task-1");
-
+    $status &= $this->deleteTaskIfExists("task-1 (From Rule Split)");
     $status &= $this->deleteHashlistIfExists("Test Rule Split");
 
     // remove the added files
@@ -108,11 +108,10 @@ class RuleSplitTest extends HashtopolisTest {
       $this->testFailed("RuleSplitTest:testRuleSplit()", sprintf("Expected benchmark to return OK."));
     } else {
       #TODO implement test for checking results
-      $filename_split = 'best64.rule' . '_p1-0';
-      if (!$this->getFile($filename_split) === false) {
+      if (!$this->getTask('task-1 (From Rule Split)') === false) {
         $this->testSuccess("RuleSplitTest:testRuleSplit()");
       } else {
-        $this->testFailed("RuleSplitTest:testRuleSplit()", sprintf("Couldn't find the created splitted rules"));
+        $this->testFailed("RuleSplitTest:testRuleSplit()", sprintf("Couldn't find the created supertask"));
       }
     }
   }
@@ -167,6 +166,23 @@ class RuleSplitTest extends HashtopolisTest {
       $query[$key] = $value;
     };
     return HashtopolisTestFramework::doRequest($query, HashtopolisTestFramework::REQUEST_UAPI);
+  }
+
+  private function getTask($name) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "task",
+      "request" => "listTasks",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+    if ($response['response'] == 'OK') {
+      foreach ($response['tasks'] as $task) {
+        if ($task['name'] == $name) {
+          return $task;
+        }
+      }
+    }
+    return false;
   }
 
   private function getFile($name) {

--- a/ci/tests/integration/RuleSplitTest.class.php
+++ b/ci/tests/integration/RuleSplitTest.class.php
@@ -66,13 +66,15 @@ class RuleSplitTest extends HashtopolisTest {
       "priority" => 100,
       "color" => "FFFFFF",
       "crackerVersionId" => 1,
-      "files" => [$file_id1, $file_id2]]
+      "files" => [$file_id1, $file_id2],
+      "chunksize" => 1],
     );
 
     $task1Id = $response["taskId"];
 
     # Enable rulesplit
-    $this->setConfig('ruleSplitDisable', '0');
+    $this->setConfig('ruleSplitDisable', false);
+    $this->setConfig('ruleSplitAlways', true);
 
     # Create agent
     $agent = $this->createAgent("agent-1");
@@ -92,31 +94,15 @@ class RuleSplitTest extends HashtopolisTest {
       "taskId" => $task1Id,
       "token" => $agent["token"],
       "type" => "speed",
-      "result" => '2000:50']
+      "result" => '2000:2200000']
     );
-    # getChunk
-    $response = HashtopolisTestFramework::doRequest([
-      "action" => "getChunk",
-      "taskId" => $task1Id,
-      "token" => $agent["token"]]
-    );
-    $chunkId = $response['chunkId'];
+    if (!is_array($response)) {
+      $this->testFailed("RuleSplitTest:testRuleSplit()", sprintf("Expected benchmark to return OK."));
+    } else {
+      $this->testSuccess("RuleSplitTest:testRuleSplit()");
+    }
 
-    # probeer de file te splitten
-    $response = HashtopolisTestFramework::doRequest([
-      "action" => "sendProgress",
-      "chunkId" => $chunkId,
-      "token" => $agent["token"],
-      "keyspaceProgress" => 500,
-      "relativeProgress" => "4545",
-      "speed" => 500,
-      "state" => 3,
-      "cracks" => [],
-      "gpuTemp" => [67],
-      "gpuUtil" => [99]
-    ]);
-
-    $this->testSuccess("RuleSplitTest:testRuleSplit()");
+    
   }
 
   private function createTask($values = []) {

--- a/ci/tests/integration/RuleSplitTest.class.php
+++ b/ci/tests/integration/RuleSplitTest.class.php
@@ -1,0 +1,265 @@
+<?php
+
+
+class RuleSplitTest extends HashtopolisTest {
+  protected $minVersion = "0.12.0";
+  protected $maxVersion = "master";
+  protected $runType    = HashtopolisTest::RUN_FAST;
+
+  public function init($version) {
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Initializing " . $this->getTestName() . "...");
+    parent::init($version);
+  }
+
+  private function prepare() {
+    $status = true;
+    // add some files
+    $status &= $this->addFile("example.dict", 0);
+    $status &= $this->addFile("best64.rule", 1);
+
+    if (!$status) {
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Some initialization failed, most likely tests will fail!");
+    }
+  }
+
+  private function cleanup() {
+    $status = true;
+    // delete the created tasks
+    $status &= $this->deleteTaskIfExists("task-1");
+    $status &= $this->deleteTaskIfExists("task-2");
+
+    // remove the added files
+    $status &= $this->deleteFileIfExists("example.dict");
+    $status &= $this->deleteFileIfExists("best64.rule");
+
+    if (!$status) {
+      HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_ERROR, "Some cleanup failed, deleting task or deleting files not succesful!");
+    }
+  }
+
+  public function run() {
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, "Running " . $this->getTestName() . "...");
+    $this->prepare();
+    try {
+      $this->testRuleSplit();
+    }
+    finally {
+      $this->cleanup();
+    }
+    HashtopolisTestFramework::log(HashtopolisTestFramework::LOG_INFO, $this->getTestName() . " completed");
+  }
+
+  private function testRuleSplit() {
+    # example.dict / best64.rule
+    $file_id1 = $this->getFile('example.dict');
+    $file_id2 = $this->getFile('best64.rule');
+
+    # Create hashlist
+    $response = $this->addHashlist(["isSecure" => false]);
+    $hashlistId = $response["hashlistId"];
+  
+    # Create task with rule/wordlist
+    $response = $this->createTask([
+      "name" => "task-1",
+      "hashlistId" => $hashlistId,
+      "attackCmd" => "#HL# -a 0 -r best64.rule example.dict",
+      "priority" => 100,
+      "color" => "FFFFFF",
+      "crackerVersionId" => 1,
+      "files" => [$file_id1, $file_id2]]
+    );
+
+    $task1Id = $response["taskId"];
+
+    # Enable rulesplit
+    $this->setConfig('ruleSplitDisable', '0');
+
+    # Create agent
+    $agent = $this->createAgent("agent-1");
+
+    HashtopolisTestFramework::doRequest(["action" => "getTask", "token" => $agent["token"]]);
+
+    # keyspace
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "sendKeyspace",
+      "taskId" => $task1Id,
+      "token" => $agent["token"],
+      "keyspace" => 10000000]
+    );
+    # benchmark
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "sendBenchmark",
+      "taskId" => $task1Id,
+      "token" => $agent["token"],
+      "type" => "speed",
+      "result" => '2000:50']
+    );
+    # getChunk
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "getChunk",
+      "taskId" => $task1Id,
+      "token" => $agent["token"]]
+    );
+    $chunkId = $response['chunkId'];
+
+    # probeer de file te splitten
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "sendProgress",
+      "chunkId" => $chunkId,
+      "token" => $agent["token"],
+      "keyspaceProgress" => 500,
+      "relativeProgress" => "4545",
+      "speed" => 500,
+      "state" => 3,
+      "cracks" => [],
+      "gpuTemp" => [67],
+      "gpuUtil" => [99]
+    ]);
+
+    $this->testSuccess("RuleSplitTest:testRuleSplit()");
+  }
+
+  private function createTask($values = []) {
+    $query = [
+      "section" => "task",
+      "request" => "createTask",
+      "name" => "",
+      "hashlistId" => 0,
+      "attackCmd" => "",
+      "chunksize" => 600,
+      "statusTimer" => 5,
+      "benchmarkType" => "speed",
+      "color" => "",
+      "isCpuOnly" => false,
+      "isSmall" => false,
+      "skip" => 0,
+      "crackerVersionId" => 0,
+      "files" => [],
+      "priority" => 0,
+      "maxAgents" => 0,
+      "preprocessorId" => 0,
+      "preprocessorCommand" => "",
+      "accessKey" => "mykey"
+    ];
+    foreach ($values as $key => $value) {
+      $query[$key] = $value;
+    }
+    return HashtopolisTestFramework::doRequest($query, HashtopolisTestFramework::REQUEST_UAPI);
+  }
+
+  private function addHashlist($values = []) {
+    $data = base64_encode(file_get_contents(dirname(__FILE__) . "/../../files/example0.hash"));
+    $query = [
+      "section" => "hashlist",
+      "request" => "createHashlist",
+      "name" => "Test Rule Split",
+      "isSalted" => false,
+      "isSecret" => true,
+      "isHexSalt" => false,
+      "separator" => ":",
+      "format" => 0,
+      "hashtypeId" => 0,
+      "accessGroupId" => 1,
+      "data" => $data,
+      "useBrain" => false,
+      "brainFeatures" => 0,
+      "accessKey" => "mykey"
+    ];
+    foreach ($values as $key => $value) {
+      $query[$key] = $value;
+    };
+    return HashtopolisTestFramework::doRequest($query, HashtopolisTestFramework::REQUEST_UAPI);
+  }
+
+  private function getFile($name) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "file",
+      "request" => "listFiles",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+    if ($response['response'] == 'OK') {
+      foreach ($response['files'] as $file) {
+        if ($file['filename'] == $name) {
+          return $file['fileId'];
+        }
+      }
+    }
+    return false;
+  }
+
+  private function addFile($name, $type) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "file",
+      "request" => "addFile",
+      "filename" => $name,
+      "fileType" => $type,
+      "source" => "inline",
+      "data" => base64_encode(file_get_contents(dirname(__FILE__) . "/../../files/$name")),
+      "accessGroupId" => 1,
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+    if ($response === false) {
+      return false;
+    }
+    else if ($response['response'] != 'OK') {
+      return false;
+    }
+    return true;
+  }
+
+  private function createAgent($name) {
+    $voucher = "voucher-" . $name;
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "createVoucher",
+      "voucher" => $voucher,
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    $response = HashtopolisTestFramework::doRequest([
+      "action" => "register",
+      "voucher" => $voucher,
+      "name" => $name]);
+    $token = $response['token'];
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "listAgents",
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    $agent = current(array_filter($response["agents"], function($a) use ($name) {
+      return $a["name"] == $name;
+    }));
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "agent",
+      "request" => "setTrusted",
+      "accessKey" => "mykey",
+      "agentId" => $agent["agentId"],
+      "trusted" => true
+    ], HashtopolisTestFramework::REQUEST_UAPI);
+    return array("agentId" => $agent["agentId"], "token" => $token);
+  }
+
+  private function setConfig($item, $value, $force = false) {
+    $response = HashtopolisTestFramework::doRequest([
+      "section" => "config",
+      "request" => "setConfig",
+      "configItem" => $item,
+      "value" => $value,
+      "force" => $force,
+      "accessKey" => "mykey"
+    ], HashtopolisTestFramework::REQUEST_UAPI
+    );
+    return $response;
+  }
+
+  private function sendProgress($token, $chunkId, $keyspaceProgress, $relateiveProgress, $speed) {
+
+  }
+  
+  public function getTestName() {
+    return "Rule Split Test";
+  }
+}
+
+HashtopolisTestFramework::register(new  RuleSplitTest());

--- a/ci/tests/integration/RuleSplitTest.class.php
+++ b/ci/tests/integration/RuleSplitTest.class.php
@@ -99,10 +99,9 @@ class RuleSplitTest extends HashtopolisTest {
     if (!is_array($response)) {
       $this->testFailed("RuleSplitTest:testRuleSplit()", sprintf("Expected benchmark to return OK."));
     } else {
+      #TODO implement test for checking results
       $this->testSuccess("RuleSplitTest:testRuleSplit()");
     }
-
-    
   }
 
   private function createTask($values = []) {

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,8 @@
 ## Bugfixes
 
 - When deleting a supertask that was created from an import, pretasks that were removed from this supertask should also be deleted (issue #865).
+- Setting config values to false using the user API now works as intended.
+- When using the rulesplit function an internal server error was thrown. (#836)
 
 ## Enhancements
 

--- a/src/inc/user-api/UserAPIConfig.class.php
+++ b/src/inc/user-api/UserAPIConfig.class.php
@@ -72,6 +72,10 @@ class UserAPIConfig extends UserAPIBasic {
         if (!is_bool($config->getValue())) {
           throw new HTException("Value most be boolean!");
         }
+        # Workaround, inserting 'false' into text field will cause an empty field.
+        if ($config->getValue() === false) {
+          $config->setValue(0);
+        }
         break;
       case DConfigType::SELECT:
         if (!in_array($config->getValue(), DConfig::getSelection($config->getItem())->getKeys())) {

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -863,8 +863,10 @@ class TaskUtils {
       for ($j = $i; $j < $i + $linesPerFile && $j < sizeof($content); $j++) {
         $copy[] = $content[$j];
       }
-      file_put_contents(dirname(__FILE__) . "/../../files/" . $splitFile->getFilename() . "_p$taskId-$count", implode("\n", $copy) . "\n");
-      $f = new File(null, $splitFile->getFilename() . "_p$taskId-$count", Util::filesize(dirname(__FILE__) . "/../../files/" . $splitFile->getFilename() . "_p$taskId-$count"), $splitFile->getIsSecret(), DFileType::TEMPORARY, $taskWrapper->getAccessGroupId());
+      $filename = $splitFile->getFilename() . "_p$taskId-$count";
+      $path = dirname(__FILE__) . "/../../files/" . $filename;
+      file_put_contents($path, implode("\n", $copy) . "\n");
+      $f = new File(null, $filename, Util::filesize($path), $splitFile->getIsSecret(), DFileType::TEMPORARY, $taskWrapper->getAccessGroupId(), Util::fileLineCount($path));
       $f = Factory::getFileFactory()->save($f);
       $newFiles[] = $f;
     }


### PR DESCRIPTION
Fixes #836 
When using speedbenchmark and you enabled settings that allowed for rulesplitting an internal server error was thrown. This fixes that issue.

Also includes fix to set config value to false using the API. Originally setting config values to false using the user API resulted in an empty string.