### PR TITLE
Removing bugged check from HashlistHandler

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,7 @@
+# v0.13.1 -> v0.x.x
+## Bugfixes
+- Setting 'Salt is in hex' during Hashlist creation will not set the --hex-salt flag (#892)
+
 # v0.13.0 -> v0.13.1
 
 ## Bugfixes

--- a/src/inc/handlers/HashlistHandler.class.php
+++ b/src/inc/handlers/HashlistHandler.class.php
@@ -80,7 +80,7 @@ class HashlistHandler implements Handler {
             $_POST['name'],
             (isset($_POST["salted"]) && intval($_POST["salted"]) == 1) ? true : false,
             (isset($_POST["secret"]) && intval($_POST["secret"]) == 1) ? true : false,
-            (isset($_POST["hexsalted"]) && (isset($_POST["secret"]) && intval($_POST["secret"]) == 1) && intval($_POST["hexsalted"]) == 1) ? true : false,
+            (isset($_POST["hexsalted"]) && intval($_POST["hexsalted"]) == 1) ? true : false,
             $_POST['separator'],
             $_POST['format'],
             $_POST['hashtype'],


### PR DESCRIPTION
In the HashlistHandler there is a weird line. It is checking if the secret value is set in the post when checking for the hexsalted value:

```
(isset($_POST["hexsalted"]) && (isset($_POST["secret"]) && intval($_POST["secret"]) == 1) && intval($_POST["hexsalted"]) == 1) ? true : false,
```

This is added since version 0.7.0 already, and this causes the hexsalted value to not work correctly. As it could not be set when creating hashlist through the UI. This pull requests fixes that.

I have spent some time for adding a test for this aswell, but because the HashlistHandler requires a lot of UI elements and in the end fire a `die()` call, I could not create a test for it.