### PR TITLE
devcontainer fixes for working with 'production' docker creation #914 

### DIFF
--- a/.devcontainer/.env.sample
+++ b/.devcontainer/.env.sample
@@ -1,4 +1,4 @@
-DEV_CONTAINER_USER_CMD_PRE='cat > /usr/local/share/ca-certificates/corporate_ca.crt << EOF
+CONTAINER_USER_CMD_PRE='cat > /usr/local/share/ca-certificates/corporate_ca.crt << EOF
 -----BEGIN CERTIFICATE-----
 <<< INSERT_PEM_FORMATTED_ROOT_CA_CHAIN_HERE >>>
 -----END CERTIFICATE-----

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,6 @@
 	"runServices": [
 		"db"
 	],
-	"appPort": [
-		8080
-	],
-	"workspaceMount": "src=${localWorkspaceFolder},dst=/var/www/html,type=bind,consistency=cached",
 	"workspaceFolder": "/var/www/html",
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,5 +51,6 @@
 	"remoteEnv": {
 		"NODE_OPTIONS": "--use-openssl-ca"
 	},
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+  "postStartCommand": "composer install --working-dir=/var/www/html/"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,4 +52,5 @@
     "NODE_OPTIONS": "--use-openssl-ca"
   },
   "remoteUser": "vscode",
+  "postStartCommand": "composer install --working-dir=/var/www/html/"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 {
 	"name": "Hashtopolis Devcontainer",
 	"dockerComposeFile": "docker-compose.yml",
-	"service": "hashtopolis-server",
+	"service": "hashtopolis-server-dev",
 	"runServices": [
-		"db"
+		"hashtopolis-db-dev"
 	],
 	"workspaceFolder": "/var/www/html",
 	"customizations": {
@@ -36,7 +36,7 @@
 							"authProtocol": "default"
 						},
 						"previewLimit": 50,
-						"server": "db",
+						"server": "hashtopolis-db-dev",
 						"port": 3306,
 						"driver": "MySQL",
 						"username": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,56 +1,55 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-	"name": "Hashtopolis Devcontainer",
-	"dockerComposeFile": "docker-compose.yml",
-	"service": "hashtopolis-server-dev",
-	"runServices": [
-		"hashtopolis-db-dev"
-	],
-	"workspaceFolder": "/var/www/html",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"xdebug.php-debug",
-				"bmewburn.vscode-intelephense-client",
-				"editorconfig.editorconfig",
-				"github.vscode-pull-request-github",
-				"ms-python.python",
-				"mtxr.sqltools",
-				"mtxr.sqltools-driver-mysql"
-			],
-			"settings": {
-				"terminal.integrated.profiles.linux": {
-					"bash": {
-						"path": "bash",
-						"icon": "terminal-bash",
-						"args": [
-							"--init-file",
-							"${workspaceFolder}/init.sh"
-						]
-					}
-				},
-				"terminal.integrated.defaultProfile.linux": "bash",
-				"sqltools.connections": [
-					{
-						"mysqlOptions": {
-							"authProtocol": "default"
-						},
-						"previewLimit": 50,
-						"server": "hashtopolis-db-dev",
-						"port": 3306,
-						"driver": "MySQL",
-						"username": "root",
-						"password": "hashtopolis",
-						"name": "DevcontainerDB",
-						"database": "hashtopolis"
-					}
-				]
-			}
-		}
-	},
-	"remoteEnv": {
-		"NODE_OPTIONS": "--use-openssl-ca"
-	},
-	"remoteUser": "vscode",
-  "postStartCommand": "composer install --working-dir=/var/www/html/"
+  "name": "Hashtopolis Devcontainer",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "hashtopolis-server-dev",
+  "runServices": [
+    "hashtopolis-db-dev"
+  ],
+  "workspaceFolder": "/var/www/html",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "xdebug.php-debug",
+        "bmewburn.vscode-intelephense-client",
+        "editorconfig.editorconfig",
+        "github.vscode-pull-request-github",
+        "ms-python.python",
+        "mtxr.sqltools",
+        "mtxr.sqltools-driver-mysql"
+      ],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash",
+            "args": [
+              "--init-file",
+              "${workspaceFolder}/init.sh"
+            ]
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "sqltools.connections": [
+          {
+            "mysqlOptions": {
+              "authProtocol": "default"
+            },
+            "previewLimit": 50,
+            "server": "hashtopolis-db-dev",
+            "port": 3306,
+            "driver": "MySQL",
+            "username": "root",
+            "password": "hashtopolis",
+            "name": "DevcontainerDB",
+            "database": "hashtopolis"
+          }
+        ]
+      }
+    }
+  },
+  "remoteEnv": {
+    "NODE_OPTIONS": "--use-openssl-ca"
+  },
+  "remoteUser": "vscode",
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       HASHTOPOLIS_DB_PASS: hashtopolis
       HASHTOPOLIS_DB_HOST: hashtopolis-db-dev
       HASHTOPOLIS_DB_DATABASE: hashtopolis
+      HASHTOPOLIS_APIV2_ENABLE: 1
     depends_on:
       - hashtopolis-db-dev
     ports:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
-  hashtopolis-server:
-    container_name: hashtopolis-server
+  hashtopolis-server-dev:
+    container_name: hashtopolis-server-dev
     build:
       context: ..
       target: hashtopolis-server-dev
@@ -11,10 +11,10 @@ services:
     environment:
       HASHTOPOLIS_DB_USER: hashtopolis
       HASHTOPOLIS_DB_PASS: hashtopolis
-      HASHTOPOLIS_DB_HOST: db
+      HASHTOPOLIS_DB_HOST: hashtopolis-db-dev
       HASHTOPOLIS_DB_DATABASE: hashtopolis
     depends_on:
-      - db
+      - hashtopolis-db-dev
     ports:
       - "8080:80"
     volumes:
@@ -23,14 +23,14 @@ services:
       - ..:/var/www/html
     networks:
       - hashtopolis_dev
-  db:
-    container_name: db
+  hashtopolis-db-dev:
+    container_name: hashtopolis-db-dev
     image: mysql:5.7
     restart: always
     ports:
       - "3306:3306"
     volumes:
-      - db:/var/lib/mysql
+      - hashtopolis-db-dev:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: hashtopolis
       MYSQL_DATABASE: hashtopolis
@@ -39,7 +39,7 @@ services:
     networks:
       - hashtopolis_dev
 volumes:
-  db:
+  hashtopolis-db-dev:
 
 networks:
   hashtopolis_dev:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestArgs": [
         "ci"
+    ],
+    "intelephense.environment.includePaths": [
+        "vendor"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,6 @@
         "ci"
     ],
     "intelephense.environment.includePaths": [
-        "vendor"
+        "../vendor"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,10 @@ RUN apt-get update \
     # Install git, procps, lsb-release (useful for CLI installs)
     && apt-get -y install git iproute2 procps lsb-release \
     && apt-get -y install mariadb-client \
+    && apt-get -y install libpng-dev \
 \
     # Install extensions (optional)
-    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install pdo_mysql gd \
 \
     # Install composer
     && curl -sS https://getcomposer.org/installer | php \
@@ -81,7 +82,9 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
 # ----BEGIN----
 FROM hashtopolis-server-base as hashtopolis-server-dev
 
-COPY --chown=www-data:www-data . /var/www/html/
+# The dev container expects the source code to be hosted at src/
+# Thus the vendor code will be hosted one dir higher.
+COPY composer.json /var/www/html/
 RUN composer install --working-dir=/var/www/html/
 
 # Setting up development requirements, install xdebug
@@ -121,6 +124,10 @@ RUN groupadd vscode && useradd -rm -d /var/www -s /bin/bash -g vscode -G www-dat
     && chown -R www-data:www-data /var/www \
     && chmod -R g+w /var/www \
     && chmod -R g+w /usr/local/share/hashtopolis
+
+# This is a seperate step so that changes to the code do not cause the container to be rebuild
+# And it will be ran last
+COPY --chown=www-data:www-data . /var/www/html/
 
 USER vscode
 # ----END----

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN apt-get update \
     # Enable URL rewriting using .htaccess
     && a2enmod rewrite
 
+# Copy source code into container
+COPY --chown=www-data:www-data ./src/ /var/www/html/
+
+# Installing php dependencies
+COPY composer.json /var/www/
+RUN composer install --working-dir=/var/www/
+
 RUN sed -i 's/KeepAliveTimeout 5/KeepAliveTimeout 10/' /etc/apache2/apache2.conf
 
 RUN mkdir /var/www/.git/
@@ -59,9 +66,6 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 # PRODUCTION Image
 # ----BEGIN----
 FROM hashtopolis-server-base as hashtopolis-server-prod
-COPY --chown=www-data:www-data ./src/ /var/www/html/
-COPY composer.json /var/www/
-RUN composer install --working-dir=/var/www/
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && touch "/usr/local/etc/php/conf.d/custom.ini" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,6 @@ RUN apt-get update \
     # Enable URL rewriting using .htaccess
     && a2enmod rewrite
 
-# Copy source code into container
-COPY --chown=www-data:www-data ./src/ /var/www/html/
-
-# Installing php dependencies
-COPY composer.json /var/www/
-RUN composer install --working-dir=/var/www/
-
 RUN sed -i 's/KeepAliveTimeout 5/KeepAliveTimeout 10/' /etc/apache2/apache2.conf
 
 RUN mkdir /var/www/.git/
@@ -67,6 +60,10 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 # ----BEGIN----
 FROM hashtopolis-server-base as hashtopolis-server-prod
 
+COPY --chown=www-data:www-data ./src/ /var/www/html/
+COPY composer.json /var/www/
+RUN composer install --working-dir=/var/www/
+
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && touch "/usr/local/etc/php/conf.d/custom.ini" \
     && echo "memory_limit = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
@@ -83,6 +80,9 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
 # DEVELOPMENT Image
 # ----BEGIN----
 FROM hashtopolis-server-base as hashtopolis-server-dev
+
+COPY --chown=www-data:www-data . /var/www/html/
+RUN composer install --working-dir=/var/www/html/
 
 # Setting up development requirements, install xdebug
 RUN yes | pecl install xdebug \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
 # ----BEGIN----
 FROM hashtopolis-server-base as hashtopolis-server-dev
 
-# Auto initialise the vendor directory within the working directory
-# to allow interactive editors to generate documentation and syntax validation
-COPY composer.json /var/www/html/
-RUN composer install --working-dir=/var/www/html/
-
 # Setting up development requirements, install xdebug
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,16 +99,17 @@ RUN yes | pecl install xdebug \
 	&& echo "upload_max_filesize = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
 	&& echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini \
 	&& echo "log_errors = On" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/custom.ini \
-    \
-    # Install python (unittests)
-    && apt-get update \
-    && apt-get install -y python3 python3-pip \
-    #TODO: Should source from ./ci/apiv2/requirements.txt
-    && pip3 install requests pytest confidence tuspy \
-    \
-    # Clean up
-    && apt-get autoremove -y \
+	&& echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/custom.ini
+
+# Install python (unittests)
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip python3-requests python3-pytest
+
+#TODO: Should source from ./ci/apiv2/requirements.txt
+RUN pip3 install confidence tuspy --break-system-packages
+
+# Clean up
+RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix dev container:
 - Allow building next to 'production' docker container (https://github.com/hashtopolis/server/wiki/Installation#docker-setup).
 - Enhance syntax highlighing by adding php composer filles in visible space.
 - Fix python test packages not able to install.
 - Enable APIv2 by default.
 - Fix .env template to work with changed DOCKER variables for working behind corporate firewalls.

Fixes are part of #914 
