### PR TITLE
Clicking pretask in Supertask create screen redirect to the pretask and not the task

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,9 @@
+# v0.14.0 -> x.x.x
+
+## Bugfixes
+- Clicking pretask in Supertask create screen now directs correctly to the pretask and not a task with the same id (#945)
+
+
 # v0.13.1 -> v0.14.0
 
 ## Tech Preview New API

--- a/src/templates/supertasks/create.template.html
+++ b/src/templates/supertasks/create.template.html
@@ -23,7 +23,7 @@
 					  <td>
 						  <input type="checkbox" name="task[]" value="[[task.getId()]]" title="Pretask">
 						  {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
-							  <a href="tasks.php?id=[[task.getId()]]" title="[[task.getAttackCmd()]]">[[task.getTaskName()]]</a>
+							  <a href="pretasks.php?id=[[task.getId()]]" title="[[task.getAttackCmd()]]">[[task.getTaskName()]]</a>
 						  {{ELSE}}
 							  [[task.getTaskName()]]
 						  {{ENDIF}}


### PR DESCRIPTION
Clicking pretask in Supertask create screen redirect to the pretask and not the task
    Fixes #945