### PR TITLE
Idea: harden innitialisation

### DIFF
--- a/src/inc/load.php
+++ b/src/inc/load.php
@@ -87,7 +87,11 @@ catch (PDOException $e) {
       Util::randomString(32),
       Util::randomString(32)
     ];
-    file_put_contents($DIRECTORIES['config'] . "/config.json", json_encode(array('PEPPER' =>$PEPPER)));
+
+    $json_config_filepath = $DIRECTORIES['config'] . "/config.json";
+    if (file_put_contents($json_config_filepath, json_encode(array('PEPPER' =>$PEPPER))) === false) {
+      die("Cannot write configuration file '$json_config_filepath'!");
+    }
   }
   
   // save version and build

--- a/src/inc/load.php
+++ b/src/inc/load.php
@@ -48,10 +48,14 @@ include(dirname(__FILE__) . "/mask.php");
 // include DBA
 require_once(dirname(__FILE__) . "/../dba/init.php");
 
-// create directories if not exists
+// create directories if not exists and ensure they are writeable
 foreach ($DIRECTORIES as $name => $path) {
   if (!file_exists($path)) {
-    mkdir($path);
+    if (mkdir($path) === false) {
+      die("Unable to create directory '$path'!");
+    }
+  } elseif (!is_writable($path)) {
+    die("Directory '$path' is not writable!");
   }
 }
 


### PR DESCRIPTION
@zyronix I would like to add some pre-flight checking to avoid errors when files cannot be written. Spotting this errors early in the process allows for some robust error messages during start/init. 

Do you see any downsides in adding them?