### PR TITLE
WIP: Add SSL integration to apache2 configuration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - hashtopolis-db-dev
     ports:
       - "8080:80"
+      - "9443:443"
     volumes:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json

--- a/.devcontainer/sites-enabled/000-default.conf
+++ b/.devcontainer/sites-enabled/000-default.conf
@@ -7,3 +7,14 @@
 		AllowOverride All
 	</Directory>
 </VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/cert.pem
+    SSLCertificateKeyFile /etc/apache2/ssl/cert-key.pem
+
+    DocumentRoot /var/www/html/src
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.buildpath
 /.project
 /.settings/
+/.devcontainer/ssl/*
 query.log
 .idea/
 *.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,17 @@ RUN apt-get update \
     && apt-get -y install git iproute2 procps lsb-release \
     && apt-get -y install mariadb-client \
     && apt-get -y install libpng-dev \
-\
+    \
     # Install extensions (optional)
     && docker-php-ext-install pdo_mysql gd \
-\
+    \
     # Install composer
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer \
     # Enable URL rewriting using .htaccess
-    && a2enmod rewrite
+    && a2enmod rewrite \
+    # Enable SSL/TLS Mod for using HTTPS
+    && a2enmod ssl
 
 RUN sed -i 's/KeepAliveTimeout 5/KeepAliveTimeout 10/' /etc/apache2/apache2.conf
 
@@ -92,16 +94,16 @@ RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
-	&& echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
     \
     # Configuring PHP
     && touch "/usr/local/etc/php/conf.d/custom.ini" \
-	&& echo "display_errors = on" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "memory_limit = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "upload_max_filesize = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "log_errors = On" >> /usr/local/etc/php/conf.d/custom.ini \
-	&& echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/custom.ini
+    && echo "display_errors = on" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "memory_limit = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "upload_max_filesize = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "log_errors = On" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "error_log = /dev/stderr" >> /usr/local/etc/php/conf.d/custom.ini
 
 # Install python (unittests)
 RUN apt-get update \
@@ -118,6 +120,11 @@ RUN apt-get autoremove -y \
 # Link our site config to the devcontainer
 RUN rm -rf /etc/apache2/sites-enabled \
     && ln -s /var/www/html/.devcontainer/sites-enabled /etc/apache2/sites-enabled
+
+# link ssl certificates to the devcontainer
+RUN mkdir -p /etc/apache2/ssl \
+    && ln -s /var/www/html/.devcontainer/ssl/cert.pem /etc/apache2/ssl/cert.pem \
+    && ln -s /var/www/html/.devcontainer/ssl/cert-key.pem /etc/apache2/ssl/cert-key.pem
 
 # Adding VSCode user and fixing permissions
 RUN groupadd vscode && useradd -rm -d /var/www -s /bin/bash -g vscode -G www-data -u 1001 vscode \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - db
     ports:
       - 8080:80
+      - 9443:443
   db:
     container_name: db
     image: mysql:5.7


### PR DESCRIPTION
Hey,

i extended the `000-default.conf` with a simple ssl configuration.
Currently you would have to add a `cert.pem` and `cert-key.pem` to `.devcontainer/ssl/`.

You can do this by running [mkcert](https://github.com/FiloSottile/mkcert) like this:

```
mkcert -install
mkcert localhost 127.0.0.1 ::1
```

Is the apache config in `.devcontainer/sites-enabled/` meant to be configured by the user? If so, then i guess #960 is fixed as well? :)

It does run without problems in the devcontainer.