### PR TITLE
Fix LikeFilter acts as case-insensitive matching

### DIFF
--- a/src/dba/LikeFilter.class.php
+++ b/src/dba/LikeFilter.class.php
@@ -35,7 +35,7 @@ class LikeFilter extends Filter {
       $inv = " NOT";
     }
     
-    return $table . $this->key . $inv . " LIKE ?";
+    return $table . $this->key . $inv . " LIKE BINARY ?";
   }
   
   function getValue() {

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -9,7 +9,7 @@ use DBA\ContainFilter;
 use DBA\Hash;
 use DBA\HashBinary;
 use DBA\Hashlist;
-use DBA\LikeFilter;
+use DBA\LikeFilterInsensitive;
 use DBA\QueryFilter;
 use DBA\Task;
 use DBA\Zap;
@@ -219,7 +219,7 @@ class APISendProgress extends APIBasic {
               $split[3] = Util::strToHex($split[3]);
               $identifier = "WPA*%*" . implode("*", $split) . "%";
             }
-            $qF1 = new LikeFilter(Hash::HASH, $identifier);
+            $qF1 = new LikeFilterInsensitive(Hash::HASH, $identifier);
           }
           else { // we use the exact match for all other hashes to avoid performance loss
             $qF1 = new QueryFilter(Hash::HASH, $splitLine[0], "=");

--- a/src/inc/handlers/SearchHandler.class.php
+++ b/src/inc/handlers/SearchHandler.class.php
@@ -4,7 +4,7 @@ use DBA\ContainFilter;
 use DBA\Hash;
 use DBA\Hashlist;
 use DBA\JoinFilter;
-use DBA\LikeFilter;
+use DBA\LikeFilterInsensitive;
 use DBA\QueryFilter;
 use DBA\Factory;
 
@@ -63,7 +63,7 @@ class SearchHandler implements Handler {
       // TODO: add option to select if exact match or like match
       
       $filters = array();
-      $filters[] = new LikeFilter(Hash::HASH, "%" . $hash . "%");
+      $filters[] = new LikeFilterInsensitive(Hash::HASH, "%" . $hash . "%");
       $filters[] = new ContainFilter(Hash::HASHLIST_ID, Util::arrayOfIds($userHashlists), Factory::getHashFactory());
       if (strlen($salt) > 0) {
         $filters[] = new QueryFilter(Hash::SALT, $salt, "=");
@@ -71,7 +71,7 @@ class SearchHandler implements Handler {
       $jF = new JoinFilter(Factory::getHashlistFactory(), Hash::HASHLIST_ID, Hashlist::HASHLIST_ID);
       $joined = Factory::getHashFactory()->filter([Factory::FILTER => $filters, Factory::JOIN => $jF]);
       
-      $qF1 = new LikeFilter(Hash::PLAINTEXT, "%" . $queryEntry . "%");
+      $qF1 = new LikeFilterInsensitive(Hash::PLAINTEXT, "%" . $queryEntry . "%");
       $qF2 = new ContainFilter(Hash::HASHLIST_ID, Util::arrayOfIds($userHashlists), Factory::getHashFactory());
       $joined2 = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::JOIN => $jF]);
       /** @var $hashes Hash[] */

--- a/src/install/updates/update.php
+++ b/src/install/updates/update.php
@@ -1,6 +1,6 @@
 <?php
 
-use DBA\LikeFilter;
+use DBA\LikeFilterInsensitive;
 use DBA\StoredValue;
 use DBA\Factory;
 
@@ -16,7 +16,7 @@ if (!isset($TEST)) {
   require_once(dirname(__FILE__) . "/../../inc/Util.class.php");
 }
 
-$qF = new LikeFilter(StoredValue::STORED_VALUE_ID, "update_%");
+$qF = new LikeFilterInsensitive(StoredValue::STORED_VALUE_ID, "update_%");
 $entries = Factory::getStoredValueFactory()->filter([Factory::FILTER => $qF]);
 $PRESENT = [];
 foreach ($entries as $entry) {


### PR DESCRIPTION
The behaviour of the LikeFilter was equal of LikeFilterInsensitive. To retain old behaviour ensure existing LikeFilter usages are converted to LikeFilterInsensitive usages.

Fixes: #968