### PR TITLE
Change DB version, because mysql 5.7 uses old collations and causing encoding errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - 8080:80
   db:
     container_name: db
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     volumes:
       - db:/var/lib/mysql


### PR DESCRIPTION
Fixes #985

There is more to this story, if any user used the old mysql version, there database are created with latin1. We could add an upgrade script to change this, but I don't like this idea because it might break stuff for people who have intentionally set the collations. My suggestion would be to create a instruction on the wiki to point to setting up the collation.

Do you agree with the solution?