### PR TITLE
Fix update priority on task does not apply to taskwrapper

### DIFF
--- a/ci/apiv2/test_task.py
+++ b/ci/apiv2/test_task.py
@@ -1,4 +1,4 @@
-from hashtopolis import Task
+from hashtopolis import Task, TaskWrapper
 from utils import BaseTest
 
 
@@ -75,3 +75,15 @@ class TaskTest(BaseTest):
         task = self.create_task(hashlist, extra_payload=extra_payload)
         obj = Task.objects.get(pk=task.id, expand='files')
         self.assertListEqual([x.id for x in files], [x.id for x in obj.files_set])
+
+    def test_task_update_priority(self):
+        task = self.create_test_object()
+        obj = TaskWrapper.objects.get(pk=task.taskWrapperId)
+        self.assertEqual(task.priority, obj.priority)
+
+        new_priority = task.priority + 1234
+        task.priority = new_priority
+        task.save()
+
+        obj = TaskWrapper.objects.get(pk=task.taskWrapperId)
+        self.assertEqual(new_priority, obj.priority)

--- a/src/inc/apiv2/model/tasks.routes.php
+++ b/src/inc/apiv2/model/tasks.routes.php
@@ -104,6 +104,13 @@ class TaskAPI extends AbstractModelAPI {
         TaskUtils::archiveTask($object->getId(), $this->getCurrentUser());
       }
 
+      /* Update connected TaskWrapper priority as well */
+      $key = Task::PRIORITY;
+      if (array_key_exists($key, $data)) {
+        array_push($processed, $key);
+        TaskUtils::updatePriority($object->getId(), $data[Task::PRIORITY], $this->getCurrentUser());
+      }
+
       parent::updateObject($object, $data, $processed);
     }
 }


### PR DESCRIPTION
The task object priority is servering asl  'dummy' for  normal tasks.

Related taskwrapper object should be updated as well,
since the 'real' priority scheduling is done using the
Taskwrapper object.

Fixes: #989