### PR TITLE
Added Vast.AI Integration

### DIFF
--- a/src/inc/defines/config.php
+++ b/src/inc/defines/config.php
@@ -108,6 +108,12 @@ class DConfig {
   const NOTIFICATIONS_PROXY_PORT   = "notificationsProxyPort";
   const NOTIFICATIONS_PROXY_TYPE   = "notificationsProxyType";
   
+  // Section: VastAI
+  const VAST_AI_API_KEY = "vastAiApiKey";
+  const VAST_IMAGE_URL = "vastImageUrl";
+  const VAST_IMAGE_LOGIN = "vastImageLogin";
+  const VAST_HASHTOPOLIS_BASE_URL = "vastHashtopolisBaseUrl";
+
   static function getConstants() {
     try {
       $oClass = new ReflectionClass(__CLASS__);
@@ -272,6 +278,14 @@ class DConfig {
         return DConfigType::TICKBOX;
       case DConfig::HC_ERROR_IGNORE:
         return DConfigType::STRING_INPUT;
+      case DConfig::VAST_AI_API_KEY:
+        return DConfigType::STRING_INPUT;
+      case DConfig::VAST_IMAGE_URL:
+        return DConfigType::STRING_INPUT;
+      case DConfig::VAST_IMAGE_LOGIN:
+        return DConfigType::STRING_INPUT;
+      case DConfig::VAST_HASHTOPOLIS_BASE_URL:
+        return DConfigType::STRING_INPUT;
     }
     return DConfigType::STRING_INPUT;
   }
@@ -406,6 +420,14 @@ class DConfig {
         return "Also send 'isComplete' for each task on the User API when listing all tasks (might affect performance)";
       case DConfig::HC_ERROR_IGNORE:
         return "Ignore error messages from crackers which contain given strings (multiple values separated by comma)";
+      case DConfig::VAST_AI_API_KEY:
+        return "Vast.ai API Key from <a href=\"https://vast.ai\">vast.ai</a>";
+      case DConfig::VAST_IMAGE_URL:
+        return "Docker image url to be loaded by Vast.ai instances. Do not change this unless you know the image to be compatible";
+      case DConfig::VAST_IMAGE_LOGIN:
+        return "Docker image login string. ex (without quotes): '-u bob -p 9d8df!fd89ufZ docker.io'. This is optional, but prevents the instances you rent from hitting the docker per-IP address rate limit. A hub.docker.com account is free to create <a href=\hub.docker.com\">here</a>. The email/password option is recommended for ease of use.";
+      case DConfig::VAST_HASHTOPOLIS_BASE_URL:
+        return "The root URL of this hashtopolis server where the Vast.ai images should connect. Note: If using HTTPS, the certificate MUST be valid. The URL MUST also be accessible via the internet. ex: https://example.com:8443";
     }
     return $config;
   }

--- a/src/inc/vastAiUtils.php
+++ b/src/inc/vastAiUtils.php
@@ -1,0 +1,254 @@
+<?php
+
+use DBA\Factory;
+
+// exists to make it easier to reference the json objects
+// from within the template
+class VastAiGPUArrayClass {
+    private $internalArray = array();
+
+    public function __construct($array) {
+        $this->internalArray = $array;
+    }
+
+    public function getUptime() {
+      if (! $this->getVal('start_date')) {
+          return null;
+      }
+      $start = (int) $this->getVal('start_date');
+      $start = round($start, 0);
+      $current = time();
+      $delta = $current - $start;
+
+      $days = floor($delta / (60 * 60 * 24));
+      $delta %= (60 * 60 * 24);
+
+      $hours = floor($delta / (60 * 60));
+      $delta %= (60 * 60);
+
+      $minutes = floor($delta / 60);
+      $seconds = $delta % 60;
+
+      $duration = '';
+
+      if ($days > 0) {
+          $duration .= $days . ' day' . ($days > 1 ? 's' : '') . ' ';
+      }
+
+      $duration .= sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
+
+      return $duration;
+    }
+
+    public function getFloatValOld($key, $precision) {
+        return round(floatval($this->internalArray[$key]), $precision);
+    }
+
+    public function getStartingVoucher() {
+        return $this->getVal('extra_env')[1][1];
+    }
+
+    public function getFloatval($key, $precision) {
+      $number = $this->getVal($key);
+      $retNumber = (float) number_format($number,0,'.','');
+      for ($n = 0; $n <= 8; $n++) {
+	    if ($retNumber === 0.0){
+	      $retNumber = (double) number_format($number,$n,'.','');
+	    } else {
+	      return number_format($number,$n+(max($precision-2,0)),'.','');
+   	    }
+      }
+      return "<0.00000000";
+    }
+
+    public function getFloatVal100($key, $precision) {
+        return round(floatval($this->internalArray[$key])*100, $precision);
+    }
+
+    public function getVal($key) {
+        if (array_key_exists($key, $this->internalArray)) {
+            return $this->internalArray[$key];
+        } else {
+            return null;
+        }
+    }
+}
+
+function vastAiDestroyInstance($apiKey, $id) {
+    $url = 'https://console.vast.ai/api/v0/instances/' . $id . '/?api_key=' . $apiKey;
+    $headers = array('Accept: application/json');
+    $options = array(
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_CUSTOMREQUEST => "DELETE"
+    );
+
+    $ch = curl_init($url);
+    $options[CURLOPT_HTTPHEADER] = $headers;
+    curl_setopt_array($ch, $options);
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    if($response === false) {
+        return 'vastaiAgentSearch curl error: ' . curl_error($ch);
+    }
+
+    return json_decode($response, true);
+}
+
+function makeVastaiVoucher($id){
+  $sub = substr(md5(rand()),0,10);
+  $voucher = $randomSubStr = 'vast' . $sub . $id;
+  AgentUtils::createVoucher($voucher);
+  return $voucher;
+}
+
+// retrieves the instances that the account is currently renting
+function getVastAiAgents($apiKey) {
+    $url = 'https://console.vast.ai/api/v0/instances?api_key=' . $apiKey;
+    $headers = array('Accept: application/json');
+    $options = array(
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+    );
+
+    $ch = curl_init($url);
+    $options[CURLOPT_HTTPHEADER] = $headers;
+    curl_setopt_array($ch, $options);
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    if($response === false) {
+        return'vastaiAgentSearch curl error: ' . curl_error($ch);
+    }
+
+    return json_decode($response, true);
+}
+
+// search current GPUs, this does not require an api key
+// an example query input value would be
+// $query = '{"verified": {"eq": true}, "external": {"eq": false}, "rentable": {"eq": true}, "compute_cap": {"gt": "600"}, "disk_space": {"gt": "10000"}, "order": [["score", "desc"]], "type": "on-demand"}';
+function searchGpus($query) {
+    $url = 'https://console.vast.ai/api/v0/bundles?q=' . urlencode($query);
+    $headers = array('Accept: application/json');
+    $options = array(
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+    );
+
+    $ch = curl_init($url);
+    $options[CURLOPT_HTTPHEADER] = $headers;
+    curl_setopt_array($ch, $options);
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    if($response === false) {
+        return'vastaiAgentSearch curl error: ' . curl_error($ch);
+    }
+
+    return json_decode($response, true);
+}
+
+function rentMachine($apiKey, $id, $imageUrl, $price, $disk, $voucher, $baseUrl, $imageLogin) {
+    // API endpoint
+    $url = 'https://console.vast.ai/api/v0/asks/' . $id . '/?api_key=' . $apiKey;
+    if ( $imageLogin === ''){
+        $imageLogin = null;
+    }
+
+    // Data to be sent
+    $data = array(
+        "client_id" => "me",
+        "image" => $imageUrl,
+        "env" => array(
+            "TZ" => "UTC",
+            "VOUCHER" => $voucher,
+            "HCATURL" => $baseUrl
+        ),
+        "disk" => (int) $disk,
+        "label" => "instance-" . $id,
+        "extra" => null,
+        "image_login" => $imageLogin,
+        "onstart" => "/root/hcat/run.sh",
+        "runtype" => "ssh",
+        "python_utf8" => false,
+        "lang_utf8" => false,
+        "use_jupyter_lab" => false,
+        "jupyter_dir" => null
+    );
+
+    // Initialize cURL session
+    $ch = curl_init();
+
+    // Set cURL options
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        'Accept: application/json',
+        'Content-Type: application/json'
+    ));
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+    // Execute the cURL request
+    $response = curl_exec($ch);
+    // REMOVE THIS LINE, for debugging
+    curl_close($ch);
+
+    // Check for any errors
+    if ($response === false) {
+        return 'cURL error: ' . curl_error($ch);
+    }
+
+    // Close cURL session
+    return json_decode($response, true);
+}
+
+function doesVoucherExist($voucher){
+  $vouchers = Factory::getRegVoucherFactory()->filter([]);
+  foreach ($vouchers as $voucher){
+    $voucherValue = $voucher->getVoucher();
+    if (str_contains($voucherValue, "vast.ai") == false){
+      continue;
+    }
+    $index = strpos($voucherValue, "-");
+    $voucherInstanceId = substr($voucherValue, $index);
+    if ($voucherInstanceId === $intsanceId){
+        return $voucherValue;
+    }
+  }
+  return null;
+}
+
+
+// given an instanceId it goes through all vouchers
+// containing the substr vast.ai and returns the 
+// voucher that contains the instanceId
+function getVoucherForInstance($instanceId){
+  $vouchers = Factory::getRegVoucherFactory()->filter([]);
+  foreach ($vouchers as $voucher){
+    $voucherValue = $voucher->getVoucher();
+    if (str_contains($voucherValue, "vast.ai") == false){
+      continue;
+    }
+    $index = strpos($voucherValue, "-");
+    $voucherInstanceId = substr($voucherValue, $index);
+    if ($voucherInstanceId === $intsanceId){
+        return $voucherValue;
+    }
+  }
+  return null;
+}
+
+function get_or($arr,$key,$default){
+    if (!$arr[$key]){
+        return $default;
+    }
+    return $arr[$key];
+}
+
+?>

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -170,7 +170,11 @@ INSERT INTO `Config` (`configId`, `configSectionId`, `item`, `value`) VALUES
   (74, 4, 'agentUtilThreshold1', '90'),
   (75, 4, 'agentUtilThreshold2', '75'),
   (76, 3, 'uApiSendTaskIsComplete', '0'),
-  (77, 1, 'hcErrorIgnore', 'DeviceGetFanSpeed');
+  (77, 1, 'hcErrorIgnore', 'DeviceGetFanSpeed'),
+  (78, 8, 'vastAiApiKey', ''),
+  (79, 8, 'vastImageUrl', 'deadjakk/hcat-vast-dev:latest'),
+  (80, 8, 'vastImageLogin', ''),
+  (81, 8, 'vastHashtopolisBaseUrl', '');
 
 CREATE TABLE `ConfigSection` (
   `configSectionId` INT(11)      NOT NULL,
@@ -184,7 +188,9 @@ INSERT INTO `ConfigSection` (`configSectionId`, `sectionName`) VALUES
   (4, 'UI'),
   (5, 'Server'),
   (6, 'Multicast'),
-  (7, 'Notifications');
+  (7, 'Notifications'),
+  (8, 'VastAI')
+;
 
 CREATE TABLE `CrackerBinary` (
   `crackerBinaryId`     INT(11)      NOT NULL,

--- a/src/templates/agents/vastai.template.html
+++ b/src/templates/agents/vastai.template.html
@@ -1,0 +1,82 @@
+{%TEMPLATE->struct/head%}
+{%TEMPLATE->struct/menu%}
+<h2>Current Vast.AI Instances</h2>
+{{IF [[vastApiKey]] === '' }}<h5><strong>Error: </strong>Missing Vast.ai API Key, add one <a href="/config.php?view=8">here</a></h5>{{ENDIF}}
+{{IF [[infoMessage]] != '' }}<h5><strong>Info:</strong> [[infoMessage]] {{ENDIF}}
+{{IF [[apiError]] != '' }}<h5><strong>Vast.ai API Error:</strong> [[apiError]] {{ENDIF}}
+{%TEMPLATE->struct/messages%}
+{%TEMPLATE->tasks/autorefresh%}
+<td>&nbsp;</td>
+<div class="card">
+  <div class="table-responsive">
+    <table class="table table-bordered table-sm" id="agents">
+      <thead>
+        <tr>
+          <th>Destroy</th>
+          <th>ID</th>
+          <th>Total Cost ($/hr)</th>
+          <th>Status</th>
+          <th>GPU(s)</th>
+          <th>GPU RAM (MB)</th>
+          <th>CPU Name</th>
+          <th>CPU Threads</th>
+          <th>CPU RAM (MB)</th>
+          <th>Verification Status</th>
+          <th>Inet Cost Upload ($/GB)</th>
+          <th>Inet Cost Download ($/GB)</th>
+          <th>Storage Cost ($/GB/Month)</th>
+          <th>Interruptible</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        {{FOREACH gpu;[[gpus]]}}
+          <tr>
+            {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_AGENT_ACCESS]])]]}} 
+              <td>
+                <form action="vastaiAgents.php" method="POST" onSubmit="if (!confirm('Really delete agent [[gpu.getVal('id')]]?')) return false;">
+                  <input type="hidden" name="destroy" value="[[gpu.getVal('id')]]">
+                  <input type="hidden" name="startingVoucher" value="[[gpu.getStartingVoucher()]]">
+                  <input type="hidden" name="csrf" value="[[csrf]]">
+                  <button type="submit" class='btn btn-warning' data-toggle="tooltip" data-placement="top" title="Destroy Instance"><i class="fas fa-trash" aria-hidden="true" ></i></button>
+                </form>
+              </td>
+            {{ELSE}}
+              <td>&nbsp;</td>
+            {{ENDIF}}
+            <td>[[gpu.getVal('id')]]</td>
+            <td>[[gpu.getFloatVal('dph_total',2)]]</td>
+            <td>[[gpu.getVal('actual_status')]]</td>
+            <td>[[gpu.getVal('gpu_name')]] x [[gpu.getVal('num_gpus')]]</td>
+            <td>[[gpu.getVal('gpu_ram')]]</td>
+            <td>[[gpu.getVal('cpu_name')]]</td>
+            <td>[[gpu.getVal('cpu_cores')]]</td>
+            <td>[[gpu.getVal('cpu_ram')]]</td>
+            <td>[[gpu.getVal('verification')]]</td>
+            <td>[[gpu.getFloatVal('inet_up_cost',2)]]</td>
+            <td>[[gpu.getFloatVal('inet_down_cost',2)]]</td>
+            <td>[[gpu.getVal('storage_cost')]]</td>
+            <td>{{IF [[gpu.getVal('is_bid')]]}} True {{ELSE}} False {{ENDIF}}</td>
+          </tr>
+          <tr>
+		  <td colspan="3">Uptime:  [[gpu.getUptime()]] <sub><br>ssh -p [[gpu.getVal('ssh_port')]] root@[[gpu.getVal('ssh_host')]]</sub> </td>
+              <td colspan="8"> [[gpu.getVal('status_msg')]] </td>
+          </tr>
+        {{ENDFOREACH}}
+      </tbody>
+    </table>
+    <script type="text/javascript">
+      $(document).ready(function () {
+        $('#agents').DataTable({
+          pageLength: 50,
+          "order": [ [0, 'asc'] ],
+          "columnDefs": [
+            { "orderable": false, "targets": [5, 7] },
+            { "orderable": true, "targets": [0, 1, 2, 3, 4, 6] }
+          ]
+        });
+      });
+    </script>
+  </div>
+</div>
+{%TEMPLATE->struct/foot%}

--- a/src/templates/agents/vastai_rent.template.html
+++ b/src/templates/agents/vastai_rent.template.html
@@ -1,0 +1,109 @@
+{%TEMPLATE->struct/head%}
+{%TEMPLATE->struct/menu%}
+<h2>Vast AI - Rent Instance</h2>
+{%TEMPLATE->struct/messages%}
+{{IF [[vastApiKey]] === '' }}<h5><strong>Error: </strong>Missing Vast.ai API Key, add one <a href="/config.php?view=8">here</a></h5>{{ENDIF}}
+{{IF [[infoMessage]] != '' }}<h5><strong>Info:</strong> [[infoMessage]] {{ENDIF}}
+{{IF [[apiError]] != '' }}<h5><strong>Vast.ai API Error:</strong> [[apiError]] {{ENDIF}}
+<div class="card">
+  <div class="table-responsive">
+    <!--Instance details-->
+    <table class="table table-bordered">
+	<div class="card">
+    <div class="table-responsive">
+    {{IF [[rentType]] != 'bulk'}}
+      <tr>
+          <td>Total Cost ($/hr)</td>
+          <td>[[gpu.getVal('dph_total')]]</td>
+      </tr>
+      <tr>
+          <td>Reliability</td>
+          <td>[[gpu.getFloatVal100('reliability2',2)]] %</td>
+      </tr>
+      <tr>
+          <td>GPU(s) Name</td>
+          <td>[[gpu.getVal('gpu_name')]] x [[gpu.getVal('num_gpus')]]</td>
+      </tr>
+      <tr>
+          <td>GPU RAM (MB)</td>
+          <td>[[gpu.getVal('gpu_ram')]]</td>
+      </tr>
+      <tr>
+          <td>CPU Name</td>
+          <td>[[gpu.getVal('cpu_name')]]</td>
+      </tr>
+      <tr>
+          <td>CPU Threads</td>
+          <td>[[gpu.getVal('cpu_cores_effective')]]</td>
+      </tr>
+      <tr>
+          <td>CPU RAM (MB)</td>
+          <td>[[gpu.getVal('cpu_ram')]]</td>
+      </tr>
+      <tr>
+          <td>Internet Upload Cost ($/GB)</td>
+          <td>[[gpu.getFloatVal('inet_up_cost',2)]]</td>
+      </tr>
+      <tr>
+          <td>Internet Download Cost ($/GB)</td>
+          <td>[[gpu.getFloatVal('inet_down_cost',2)]]</td>
+      </tr>
+      <tr>
+          <td>Storage Cost ($/GB/Month)</td>
+          <td>[[gpu.getFloatVal('storage_cost',2)]]</td>
+      </tr>
+      <tr>
+          <td>Verification Status</td>
+          <td>[[gpu.getVal('verification')]]</td>
+      </tr>
+      <tr>
+          <td>Rentable</td>
+          <td>{{IF [[gpu.getVal('rentable')]]}} True {{ELSE}} False {{ENDIF}}</td>
+      </tr>
+      <tr>
+          <td>Interruptible</td>
+          <td>{{IF [[gpu.getVal('is_bid')]]}} True {{ELSE}} False {{ENDIF}}</td>
+      </tr>
+    </div>
+    </div>
+    </table>
+
+    <!--User-definable values-->
+    <form action="vastaiAgentsRent.php" method="POST">
+    <input type="hidden" name="csrf" value="[[csrf]]">
+    <table class="table table-bordered">
+	<div class="card">
+    <div class="table-responsive">
+      <tr>
+        <td>ID</td>
+        <td>[[gpu.getVal('id')]]</td>
+        <input type="hidden" name="rent" value="single">
+        <input type="hidden" value="on" name="vastid-[[gpu.getVal('id')]]">
+      </tr>
+      <tr>
+        <td>Price ($/Hr)</td>
+        <td><input type="text" disabled="disabled" class='form-control' name="price" value="[[gpu.getVal('dph_total')]]"></td>
+      </tr>
+      <tr>
+        <td>Disk Storage Needed (GB)</td>
+        <td><input type="text" class='form-control' name="disk" value="16"></td>
+      </tr>
+      <tr>
+          {{ENDIF}}
+        {{IF [[posted]] === true }}
+          {{IF [[rentSuccess]] === true }}
+            <td colspan="2">RENTAL SUCCESSFUL, Your image should appear <a href="vastaiAgents.php">here</a> in a few seconds. It may take between 3 to 15 minutes to join hashtopolis, depending on the instance.</td>
+          {{ELSE}}
+            <td colspan="2">RENTAL FAILED, error: [[rentError]]</td>
+          {{ENDIF}}
+        {{ELSE}}
+        <td colspan="2"><input {{IF [[posted]] === true}}disabled="disabled"{{ENDIF}} type="submit" class='form-control btn-success' value="RENT THIS INSTANCE" ></td>
+        {{ENDIF}}
+      </tr>
+    </div>
+    </div>
+    </table>
+    </form>
+  </div>
+</div>
+{%TEMPLATE->struct/foot%}

--- a/src/templates/agents/vastai_search.template.html
+++ b/src/templates/agents/vastai_search.template.html
@@ -1,0 +1,78 @@
+{%TEMPLATE->struct/head%}
+{%TEMPLATE->struct/menu%}
+<h2>Search Vast.AI</h2>
+{{IF [[vastApiKey]] === '' }}<h5><strong>Error: </strong>Missing Vast.ai API Key, add one <a href="config.php?view=8">here</a></h5>{{ENDIF}}
+{{IF [[infoMessage]] != '' }}<h5><strong>Info:</strong> [[infoMessage]] {{ENDIF}}
+{{IF [[apiError]] != '' }}<h5><strong>Vast.ai API Error:</strong> [[apiError]] {{ENDIF}}
+{%TEMPLATE->struct/vastaifilter%}
+{%TEMPLATE->struct/messages%}
+        <form action="vastaiAgentsRent.php" method="POST" onSubmit="if (!confirm('Please note this will charge the Vast.ai account associated with the account. Please see the instances page to view additional costs associated with each rented instance.')) return false;">
+        <div style="display: flex; align-items: center;">
+        <input class="btn btn-warning" style="margin-right: 10px" type="submit" value="Rent Checked"/>
+        <strong><label style="padding: 8px 12px;" size="10">Disk Size (GB): </label></strong>
+        <input type="text" class="form-control" name="disk" value="8" style="width: 60px;margin-right: 10px;" maxlength="8">
+        </div>
+
+        <input type="hidden" name="csrf" value="[[csrf]]" />
+        <input type="hidden" name="rent" value="bulk"/>
+        <br /> <br />
+<div class="card">
+  <div class="table-responsive">
+    <table class="table table-bordered table-sm" id="agents">
+      <thead>
+        <tr>
+          <th>Rent</th>
+          <th>ID</th>
+          <th>Total Cost ($/hr)</th>
+          <th>Reliability</th>
+          <th>GPU(s) Name</th>
+          <th>GPU #</th>
+          <th>GPU RAM (MB)</th>
+          <th>CPU Name</th>
+          <th>CPU Threads</th>
+          <th>CPU RAM (MB)</th>
+          <th>Verification Status</th>
+          <th>Interruptible</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{FOREACH gpu;[[gpus]]}}
+          <tr>
+            {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_AGENT_ACCESS]])]]}} 
+              <td style="text-align: center; vertical-align: middle;">
+                <input type="checkbox" name="vastid-[[gpu.getVal('id')]]">
+              </td>
+            {{ELSE}}
+              <td>&nbsp;</td>
+            {{ENDIF}}
+            <td><a title="See Details" href="vastaiAgentsRent.php?rent=[[gpu.getVal('id')]]">[[gpu.getVal('id')]]</a></td>
+            <td>[[gpu.getVal('dph_total')]]</td>
+            <td>[[gpu.getFloatVal100('reliability2',0)]] %</td>
+            <td>[[gpu.getVal('gpu_name')]]</td>
+            <td>[[gpu.getVal('num_gpus')]]</td>
+            <td>[[gpu.getVal('gpu_ram')]]</td>
+            <td>[[gpu.getVal('cpu_name')]]</td>
+            <td>[[gpu.getVal('cpu_cores')]]</td>
+            <td>[[gpu.getVal('cpu_ram')]]</td>
+            <td>[[gpu.getVal('verification')]]</td>
+            <td>{{IF [[gpu.getVal('is_bid')]]}} True {{ELSE}} False {{ENDIF}}</td>
+          </tr>
+        {{ENDFOREACH}}
+        </form> 
+      </tbody>
+    </table>
+    <script type="text/javascript">
+      $(document).ready(function () {
+        $('#agents').DataTable({
+          pageLength: 50,
+          "order": [ [0, 'asc'] ],
+          "columnDefs": [
+            { "orderable": false, "targets": [] },
+            { "orderable": true, "targets": [0, 1, 2, 3, 4, 5, 6, 7] }
+          ]
+        });
+      });
+    </script>
+  </div>
+</div>
+{%TEMPLATE->struct/foot%}

--- a/src/templates/config.template.html
+++ b/src/templates/config.template.html
@@ -12,6 +12,7 @@
     <button onclick="window.location='config.php?view=5'" type="button" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark{{ELSE}}btn-light{{ENDIF}}{{IF [[configSectionId]] == 5}} active{{ENDIF}}">Server</button>
     <button onclick="window.location='config.php?view=6'" type="button" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark{{ELSE}}btn-light{{ENDIF}}{{IF [[configSectionId]] == 6}} active{{ENDIF}}">Multicast</button>
     <button onclick="window.location='config.php?view=7'" type="button" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark{{ELSE}}btn-light{{ENDIF}}{{IF [[configSectionId]] == 7}} active{{ENDIF}}">Notifications</button>
+    <button onclick="window.location='config.php?view=8'" type="button" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark{{ELSE}}btn-light{{ENDIF}}{{IF [[configSectionId]] == 8}} active{{ENDIF}}">Vast.AI</button>
   </div>
 </div>
 
@@ -38,7 +39,7 @@
 					  <td>[[DConfig::getConfigDescription([[conf.getVal('item')]])]]</td>
 					  <td>
 						  {{IF [[DConfig::getConfigType([[conf.getVal('item')]])]] == "string"}}
-							  <input type="text" class='form-control' name="config_[[conf.getVal('item')]]" value="[[Util::escapeSpecial([[conf.getVal('value')]])]]" title="Config Value">
+                          <input type="text" class='form-control' name="config_[[conf.getVal('item')]]" value="[[Util::escapeSpecial([[conf.getVal('value')]])]]" title="Config Value" {{IF [[configSectionId]] == 8 }} size="100" {{ENDIF}}>
 						  {{ENDIF}}
 						  {{IF [[DConfig::getConfigType([[conf.getVal('item')]])]] == "number"}}
 							  <input type="number" class='form-control' name="config_[[conf.getVal('item')]]" value="[[Util::escapeSpecial([[conf.getVal('value')]])]]" title="Config Value">

--- a/src/templates/struct/menu.template.html
+++ b/src/templates/struct/menu.template.html
@@ -19,6 +19,12 @@
                         {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_AGENT_ACCESS]])]]}}
 							<a class="dropdown-item[[menu.isActive('agents_status')]]" href="agentStatus.php">Agent Status</a>
 						{{ENDIF}}
+                        {{IF [[accessControl.hasPermission([[$DAccessControl::CREATE_AGENT_ACCESS]])]]}}
+							<a class="dropdown-item[[menu.isActive('vast_ai_agents')]]" href="vastaiAgents.php">Show Rented Vast.AI Agents</a>
+						{{ENDIF}}
+                        {{IF [[accessControl.hasPermission([[$DAccessControl::CREATE_AGENT_ACCESS]])]]}}
+							<a class="dropdown-item[[menu.isActive('vast_ai_agents_search')]]" href="vastaiAgentsSearch.php">Search Vast.AI Agents</a>
+						{{ENDIF}}
 					</div>
 				</li>
 			{{ENDIF}}

--- a/src/templates/struct/vastaifilter.template.html
+++ b/src/templates/struct/vastaifilter.template.html
@@ -1,0 +1,47 @@
+<form action="vastaiAgentsSearch.php" method="GET">
+    <input type='hidden' name='search' value='true'>
+    <input type="hidden" name="csrf" value="[[csrf]]">
+
+    <table class="table table-bordered table-sm" >
+    <thead>
+        <th> Max Cost ($/hr)</th>
+        <th> GPU Name</th>
+        <th> Min GPU RAM (MB)</th>
+        <th> Min CPU RAM (MB)</th>
+    </thead>
+    <tr>
+        <td> <input type="text" class="form-control" name="dph_total" value="[[search_dph_total]]" size=10> </td>
+        <td> <input type="text" class="form-control" name="gpu_name" value="[[search_gpu_name]]" size=10> </td>
+        <td> <input type="text" class="form-control" name="gpu_ram" value="[[search_gpu_ram]]" size=10> </td>
+        <td> <input type="text" class="form-control" name="cpu_ram" value="[[search_cpu_ram]]" size=10> </td>
+    </tr>
+    <thead>
+        <th>Disk Size (GB)</th>
+        <th>CPU Threads</th>
+        <th> Reliability (.8 is 80%)</th>
+    </thead>
+    <tr>
+        <td> <input type="text" class="form-control" name="disk_size" value="[[search_disk_size]]" size=10> </td>
+        <td> <input type="text" class="form-control" name="cpu_cores" value="[[search_cpu_cores]]" size=10> </td>
+        <td> <input type="text" class="form-control" name="reliability2" value="[[search_reliability2]]" size=10> </td>
+    </tr>
+
+    <tr>
+        <input type="hidden" name="verified" value="off" />
+        <td colspan="5"> Verified: <input colspan="5" type="checkbox" name="verified" size="10" {{IF [[verifiedChecked]] == true}} checked="checked" {{ENDIF}}> </td>
+    </tr>
+    <tr>
+        <input type="hidden" name="uninterruptible" value="off" />
+        <td colspan="5"> Uninterruptible (cannot be outbid): <input type="checkbox" name="uninterruptible" size="10" {{IF [[uninterruptibleChecked]] == true}} checked="checked" {{ENDIF}}> </td>
+    </tr>
+    <tr>
+        <input type="hidden" name="datacenter" value="off" />
+        <td colspan="5"> Trusted Datacenters Only (secure cloud): <input type="checkbox" name="datacenter" size="10" {{IF [[datacenterChecked]] == true}} checked="checked" {{ENDIF}}> </td>
+    </tr>
+    <tr>
+        <td colspan="5"><input class="btn btn-success" type="submit" value="Search GPUs"/></td>
+    </tr>
+
+    </table>
+</form>
+<br>

--- a/src/vastaiAgents.php
+++ b/src/vastaiAgents.php
@@ -1,0 +1,117 @@
+<?php
+
+use DBA\RegVoucher;
+use DBA\Config;
+use DBA\AccessGroup;
+use DBA\AccessGroupAgent;
+use DBA\AccessGroupUser;
+use DBA\Agent;
+use DBA\AgentError;
+use DBA\Assignment;
+use DBA\Chunk;
+use DBA\ContainFilter;
+use DBA\JoinFilter;
+use DBA\OrderFilter;
+use DBA\QueryFilter;
+use DBA\Factory;
+
+require_once(dirname(__FILE__) . "/inc/load.php");
+require_once(dirname(__FILE__) . "/inc/vastAiUtils.php");
+
+if (!Login::getInstance()->isLoggedin()) {
+  header("Location: index.php?err=4" . time() . "&fw=" . urlencode($_SERVER['PHP_SELF'] . "?" . $_SERVER['QUERY_STRING']));
+  die();
+}
+
+AccessControl::getInstance()->checkPermission(DViewControl::AGENTS_VIEW_PERM);
+
+Template::loadInstance("agents/vastai");
+Menu::get()->setActive("vast_ai_agents");
+
+//catch actions here...
+if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
+  $agentHandler = new AgentHandler(@$_POST['agentId']);
+  $agentHandler->handle($_POST['action']);
+  if (UI::getNumMessages() == 0) {
+    Util::refresh();
+  }
+}
+
+$vastaiApiKey = SConfig::getInstance()->getVal(Dconfig::VAST_AI_API_KEY);
+$apiError = '';
+$infoMessage = '';
+
+UI::add('vastApiKey',$vastaiApiKey);
+UI::add('pageTitle', "Vast.AI Agents");
+
+// DESTROY LOGIC
+if (isset($_POST['destroy']) && AccessControl::getInstance()->hasPermission(DAccessControl::MANAGE_AGENT_ACCESS)) {
+  if ($_POST['destroy'] === '' ){
+    echo "No machine id provided for the destroy action";
+    die();
+  }
+  $machineId = $_POST['destroy'];
+
+  $response = vastAiDestroyInstance($vastaiApiKey, $machineId);
+  if (isset($response['error'])) {
+      $apiError .= "vast.ai get instances error: " . $response;
+  } else if (isset($response['success'])) {
+      $infoMessage = 'Successfully destroyed instance: ' . $machineId;
+  } else {
+      $apiError .= "vast.ai get instances error: " . $response;
+  }
+
+  // REMOVE VOUCHER FOR DESTROYED INSTANCE IF IT HASNT BEEN USED YET
+  if (isset($_POST['startingVoucher']) && $_POST['startingVoucher'] != '') {
+    $qF = new QueryFilter(RegVoucher::VOUCHER, $_POST['startingVoucher'], "=");
+    $check = Factory::getRegVoucherFactory()->filter([Factory::FILTER => $qF]);
+    if ( $check != null ) {
+      AgentUtils::deleteVoucher($_POST['startingVoucher']);
+    }
+  }
+} 
+
+// INSTANCE LIST LOGIC to list the current vast.ai instances associated with the api key
+$response = getVastAiAgents($vastaiApiKey);
+if (isset($response['error'])) {
+    $apiError .= "vast.ai get instances error: " . $response;
+} else if (isset($response['instances']) == true) {
+  $gpus = array();
+  foreach ($response['instances'] as $gpu) {
+      $gpuClassInstance = new VastAiGPUArrayClass($gpu);
+      array_push($gpus, $gpuClassInstance);
+  }
+} else {
+    $apiError .= 'missing instances, response: ' . var_export($response, true);
+}
+
+// TEST IF AUTO-RELOAD IS ENABLED
+$autorefresh = 0;
+if (isset($_COOKIE['autorefresh']) && $_COOKIE['autorefresh'] == '1') {
+  $autorefresh = 10;
+}
+if (isset($_POST['toggleautorefresh'])) {
+  if ($autorefresh != 0) {
+    $autorefresh = 0;
+    setcookie("autorefresh", "0", time() - 600);
+  }
+  else {
+    $autorefresh = 10;
+    setcookie("autorefresh", "1", time() + 3600 * 24);
+  }
+  Util::refresh();
+}
+if ($autorefresh > 0) { //renew cookie
+  setcookie("autorefresh", "1", time() + 3600 * 24);
+}
+
+UI::add('autorefresh', 0);
+if (isset($_GET['id']) || !isset($_GET['new'])) {
+  UI::add('autorefresh', $autorefresh);
+  UI::add('autorefreshUrl', "");
+}
+
+UI::add('infoMessage', $infoMessage);
+UI::add('apiError', $apiError);
+UI::add('gpus', $gpus);
+echo Template::getInstance()->render(UI::getObjects());

--- a/src/vastaiAgentsRent.php
+++ b/src/vastaiAgentsRent.php
@@ -1,0 +1,142 @@
+<?php
+
+use DBA\Factory;
+use DBA\Config;
+use DBA\AccessGroup;
+use DBA\AccessGroupAgent;
+use DBA\AccessGroupUser;
+use DBA\Agent;
+use DBA\AgentError;
+use DBA\Assignment;
+use DBA\Chunk;
+use DBA\ContainFilter;
+use DBA\JoinFilter;
+use DBA\OrderFilter;
+use DBA\QueryFilter;
+
+require_once(dirname(__FILE__) . "/inc/load.php");
+require_once(dirname(__FILE__) . "/inc/vastAiUtils.php");
+
+if (!Login::getInstance()->isLoggedin()) {
+  header("Location: index.php?err=4" . time() . "&fw=" . urlencode($_SERVER['PHP_SELF'] . "?" . $_SERVER['QUERY_STRING']));
+  die();
+}
+
+AccessControl::getInstance()->checkPermission(DViewControl::AGENTS_VIEW_PERM);
+
+//catch actions here...
+if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
+  $agentHandler = new AgentHandler(@$_POST['agentId']);
+  $agentHandler->handle($_POST['action']);
+  if (UI::getNumMessages() == 0) {
+    Util::refresh();
+  }
+}
+
+Template::loadInstance("agents/vastai_rent");
+
+$apiError = '';
+$infoMessage = '';
+$rentError = '';
+$vastaiApiKey = SConfig::getInstance()->getVal(Dconfig::VAST_AI_API_KEY);
+$rentSuccess = false;
+UI::add('vastApiKey', $vastaiApiKey);
+
+if (isset($_POST['rent']) && AccessControl::getInstance()->hasPermission(DAccessControl::CREATE_AGENT_ACCESS)) {
+  UI::add('rentType',$_POST['rent']);
+  foreach(array_keys($_POST) as $postKey){
+    if (strpos($postKey, 'vastid-') !== 0) {
+        continue;
+    }
+
+    $id = substr($postKey, strlen('vastid-'));
+    $query = array("id" => array("eq" => $id ));
+
+    // PULL the details for the provided id
+    $response = searchGpus(json_encode($query));
+    if (isset($response['error'])) {
+        $apiError .= "vast.ai get offers error: " . $response . "<br>";
+    } else if (isset($response['offers']) == true) {
+      if (sizeof($response['offers']) == 1){
+        $gpu = new VastAiGPUArrayClass($response['offers'][0]);
+        UI::add('gpu', $gpu);
+      } else if (sizeof($response['offers']) > 1){
+        $apiError .= 'results were ambiguous for provided machine id<br>';
+      } else {
+        $apiError .= 'no results found for provided machine id<br>';
+      }
+    } else {
+      $apiError  = 'missing offer key, response: ' . var_export($response , true) . '<br>';
+    }
+
+    // RENT LOGIC
+    $imageUrl = SConfig::getInstance()->getVal(Dconfig::VAST_IMAGE_URL);
+    $baseUrl = SConfig::getInstance()->getVal(Dconfig::VAST_HASHTOPOLIS_BASE_URL);
+    $vastaiImageLogin = SConfig::getInstance()->getVal(Dconfig::VAST_IMAGE_LOGIN);
+
+    if ($baseUrl === '') {
+      echo 'No base url string was set. set it <a href="/config.php?view=8">here</a><br>';
+      die();
+    }
+    if ($imageUrl === '') {
+      echo 'No image url string was set. set it <a href="/config.php?view=8">here</a><br>';
+      die();
+    }
+    if (isset($_POST['disk']) === false || $_POST['disk'] === '') {
+      echo 'A disk value must be set.<br>';
+      die();
+    }
+    if (isset($_POST['price']) === false || $_POST['price'] === ''){
+      $price = null;
+    }
+
+    $disk  = $_POST['disk'];
+    $price = $_POST['price'];
+    // this additional substring gets referenced to properly remove
+    // voucher and agent artifacts by the destroy function.
+    // it is also intuitive when checking agents/vouchers.
+    $voucher = makeVastaiVoucher($id);
+
+    $response = rentMachine($vastaiApiKey, $id, $imageUrl, $price, $disk, $voucher, $baseUrl, $vastaiImageLogin);
+    if (isset($response['error'])) {
+        $rentError .= "vast.ai error: " . $response['msg'];
+    } else if (isset($response['success'])) {
+        $infoMessage .= '<br>Successfully rented: ' . $id;
+        $rentSuccess = true;
+    } else {
+        $rentError .= "vast.ai error: " . $response . '<br>';
+    }
+
+  }
+
+  UI::add('posted', true);
+  UI::add('rentError', $rentError);
+  UI::add('infoMessage', $infoMessage);
+  UI::add('rentSuccess', $rentSuccess);
+} else if (isset($_GET['rent']) && AccessControl::getInstance()->hasPermission(DAccessControl::CREATE_AGENT_ACCESS)) {
+  // VIEWING DETAILS
+  $id = $_GET['rent'];
+  $query = array("id" => array("eq" => $id ));
+  $response = searchGpus(json_encode($query));
+  if (is_array($response) === false){
+      $apiError .= $response . "\n";
+  }
+  if (isset($response['offers']) == true) {
+    if (sizeof($response['offers']) == 1){
+      $gpu = new VastAiGPUArrayClass($response['offers'][0]);
+      UI::add('gpu', $gpu);
+    } else if (sizeof($response['offers']) > 1){
+      $apiError .= 'results were ambiguous for provided machine id' . "\n";
+    } else {
+      $apiError .= 'no results found for provided machine id' . "\n";
+    }
+  } else {
+      $apiError .= 'missing offer key, response: ' . var_export($response, true) . "\n";
+  }
+} else {
+    echo "Error: No rent param provided";
+    die();
+}
+
+UI::add('apiError', $apiError);
+echo Template::getInstance()->render(UI::getObjects());

--- a/src/vastaiAgentsSearch.php
+++ b/src/vastaiAgentsSearch.php
@@ -1,0 +1,133 @@
+<?php
+
+use DBA\Config;
+use DBA\AccessGroup;
+use DBA\AccessGroupAgent;
+use DBA\AccessGroupUser;
+use DBA\Agent;
+use DBA\AgentError;
+use DBA\Assignment;
+use DBA\Chunk;
+use DBA\ContainFilter;
+use DBA\JoinFilter;
+use DBA\OrderFilter;
+use DBA\QueryFilter;
+use DBA\Factory;
+
+require_once(dirname(__FILE__) . "/inc/load.php");
+require_once(dirname(__FILE__) . "/inc/vastAiUtils.php");
+
+if (!Login::getInstance()->isLoggedin()) {
+  header("Location: index.php?err=4" . time() . "&fw=" . urlencode($_SERVER['PHP_SELF'] . "?" . $_SERVER['QUERY_STRING']));
+  die();
+}
+
+AccessControl::getInstance()->checkPermission(DViewControl::AGENTS_VIEW_PERM);
+
+Template::loadInstance("agents/vastai_search");
+Menu::get()->setActive("vast_ai_agents_search");
+
+//catch actions here...
+if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
+  $agentHandler = new AgentHandler(@$_POST['agentId']);
+  $agentHandler->handle($_POST['action']);
+  if (UI::getNumMessages() == 0) {
+    Util::refresh();
+  }
+}
+
+$trueKeys = array('verified', 'datacenter');
+$ltNumKeys = array('dph_total', 'dph');
+$gtKeys = array('cpu_ram', 'gpu_ram', 'reliability2', 'disk_size', 'cpu_cores');
+$eqKeys = array('gpu_name', 'cpu_name');
+$vastaiApiKey = SConfig::getInstance()->getVal(Dconfig::VAST_AI_API_KEY);
+UI::add('vastApiKey',$vastaiApiKey);
+
+// maintain current search values / set default values
+UI::add('search_gpu_name',get_or($_GET, 'gpu_name', ''));
+UI::add('search_dph_total',$_GET['dph_total'] ?? '.4');
+UI::add('search_gpu_ram',$_GET['gpu_ram'] ?? '');
+UI::add('search_cpu_ram',$_GET['cpu_ram'] ?? '');
+UI::add('search_disk_size',$_GET['disk_size'] ?? 8);
+UI::add('search_cpu_cores',$_GET['cpu_cores'] ?? '');
+UI::add('search_reliability2',$_GET['reliability2'] ?? '.8');
+
+if (isset($_GET['datacenter']) === false || $_GET['datacenter'] === 'on'){
+    // default setting
+    UI::add('datacenterChecked',true);
+} else {
+    UI::add('datacenterChecked',false);
+} 
+
+if (isset($_GET['verified']) === false || $_GET['verified'] === 'on'){
+    // default setting
+    UI::add('verifiedChecked',true);
+} else {
+    UI::add('verifiedChecked',false);
+} 
+
+if (isset($_GET['uninterruptible']) === false || $_GET['uninterruptible'] === 'on'){
+    // default setting
+    UI::add('uninterruptibleChecked',true);
+} else {
+    UI::add('uninterruptibleChecked',false);
+} 
+
+UI::add('pageTitle', "Vast.AI Search");
+$apiError = '';
+if (isset($_GET['search']) && AccessControl::getInstance()->hasPermission(DAccessControl::MANAGE_AGENT_ACCESS)) {
+  // prepare the query, I do not like this method of doing this, but it is working
+  $query = array();
+  $query = array_merge($query, array( "rentable" => array("eq" => true)));
+  $query = array_merge($query, array( "rented" => array("eq" => false)));
+
+  if(isset($_GET['uninterruptible']) == true && $_GET['uninterruptible'] == 'on'){
+      $query = array_merge($query, array("type" => "ask"));
+  } else {
+      $query = array_merge($query, array("type" => "bid"));
+  }
+
+  foreach ($trueKeys as $key) {
+    if (isset($_GET[$key]) === true && $_GET[$key] !== ''){
+      if ($_GET[$key] == 'on'){
+        $query = array_merge($query, array( $key => array("eq" => true)));
+      }
+    }
+  }
+
+  foreach ($eqKeys as $key) {
+    if (isset($_GET[$key]) === true && $_GET[$key] !== ''){
+      $query = array_merge($query, array( $key => array("eq" => $_GET[$key])));
+    }
+  }
+
+  foreach ($ltNumKeys as $key) {
+    if (isset($_GET[$key]) === true && $_GET[$key] !== ''){
+      $query = array_merge($query, array( $key => array("lte" => $_GET[$key])));
+    }
+  }
+
+  foreach ($gtKeys as $key) {
+    if (isset($_GET[$key]) === true && $_GET[$key] !== ''){
+      $query = array_merge($query, array( $key => array("gte" => $_GET[$key])));
+    }
+  }
+
+  // make the query
+  $response = searchGpus(json_encode($query));
+  if (isset($response['error'])) {
+      $apiError .= "vast.ai get offers error: " . $response;
+  } else if (isset($response['offers']) == true) {
+    $gpus = array();
+    foreach ($response ['offers'] as $gpu) {
+        $gpuClassInstance = new VastAiGPUArrayClass($gpu);
+        array_push($gpus, $gpuClassInstance);
+    }
+  } else {
+    $apiError  = 'missing offer key, response: ' . var_export($response , true);
+  }
+}
+
+UI::add('apiError', $apiError);
+UI::add('gpus', $gpus);
+echo Template::getInstance()->render(UI::getObjects());


### PR DESCRIPTION
You probably are already aware of [vast.ai](https://vast.ai), it's uber for GPUs.   
This PR adds a few more pages to hashtopolis to facilitate 1-2 click en-masse deployment
of agents by leveraging vast.ai's API.  
The goal was to add the ability to deploy and destroy complete cracking
infrastructure in as few clicks as possible.

I am also happy to maintain this portion of code if needed, and will plan to add the same functionality to the node version of hashtopolis once that is in a more mature state.  

One caveat: vast.ai instances are not all created equal, therefore some still throw 'weird' errors from time to time but using the default search parameters I have provided in the code I have had pretty good luck; about an 80%-90% success rate on average, YMMV.

It adds:
- Vast.ai instance search/rental page with a multi-purchase option
- Vast.ai instance management page using live values from vast.ai and an auto-refresh function
- Auto deployment upon renting using a [docker image I published](https://hub.docker.com/repository/docker/deadjakk/hcat-vast-dev/general) (Dockerfile provided below)
- New config values under config > Server > Vast.ai section to support this

It is missing:
1. docs - I am waiting to see if this is going to be accepted before bothering with this
2. auto agent deletion when an instance is released/destroyed from vast.ai - to do this properly, I will need to add a 'tag' flag to the hashtopolis agent and server api so that I can be certain about which instance is which
3. custom cert package downloads to allow for unsigned ssl connections  
4. update file addition to add the new configuration values, something like the code block below 

```
$config = new Config(null, 8, DConfig::VAST_AI_API_KEY, '');
Factory::getConfigFactory()->save($config);
$config = new Config(null, 8, DConfig::VAST_IMAGE_URL, '');
Factory::getConfigFactory()->save($config);
$config = new Config(null, 8, DConfig::VAST_IMAGE_LOGIN, '');
Factory::getConfigFactory()->save($config);
$config = new Config(null, 8, DConfig::VAST_HASHTOPOLIS_BASE_URL, '');
Factory::getConfigFactory()->save($config);
```

Below is the Dockerfile so you can publish it via your own hub.docker.com account and have control over it.   
# Dockerfile
```
FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
# Example of successful usage command
# YOU MUST HAVE VALID SSL CERTS IF USING AN HTTPS SERVER !!!!
#
# to run independent of hashtopolis:
# sudo docker build . -t hcat
# sudo docker run -it -e HCATURL="https://localhost:9090" -e VOUCHER="GF30HJEx" hcat

RUN apt update && \
   apt install -y curl zip python3 python3-psutil python3-requests pciutils pocl-opencl-icd

RUN mkdir -p /root/hcat

WORKDIR /root/hcat

RUN echo 'curl -k "$HCATURL/agents.php?download=1" -o agent.zip' > run.sh
RUN echo 'unzip agent.zip' >> run.sh
RUN echo 'python3 . --voucher $VOUCHER --url "$HCATURL/api/server.php"' >> run.sh
RUN chmod +x run.sh

## This will not get run by vast.ai, so this really only exists for use outside of vast.ai
CMD curl -k "$HCATURL/agents.php?download=1" -o agent.zip && \
    unzip agent.zip && \
    python3 . --voucher $VOUCHER --url "$HCATURL/api/server.php"
```

# Images of use  
Searching for instances
![search-instances](https://github.com/hashtopolis/server/assets/30613497/12819693-80b3-4d77-8f92-fb4369c4276b)
Renting instance
![successful-rent](https://github.com/hashtopolis/server/assets/30613497/eccf4b24-3105-4166-a6b3-26cfcde1f4b6)
Rented instances
![rented-instances](https://github.com/hashtopolis/server/assets/30613497/6fb80a1f-1ab5-418e-b32c-78a8a437030f)
Agents 'received'
![instace-agents](https://github.com/hashtopolis/server/assets/30613497/a5f47959-9bac-4507-b2cc-cb00dfb4e117)
