### PR TITLE
Add support for double salted hashes

### DIFF
--- a/src/getFound.php
+++ b/src/getFound.php
@@ -58,7 +58,10 @@ switch ($format) {
         foreach ($current as $entry) {
           $output .= $entry->getHash();
           if (strlen($entry->getSalt()) > 0) {
-            $output .= "\t" . $entry->getSalt();
+            $salts = explode($hashlist->getSaltSeparator(), $entry->getSalt()); // Double salt
+            foreach ($salts as $salt) {
+              $output .= "\t" . $salt;
+            }
           }
           $output .= "\tFF" . $lineDelimiter;
         }

--- a/src/getHashlist.php
+++ b/src/getHashlist.php
@@ -69,10 +69,14 @@ switch ($format) {
         
         $output = "";
         $count += sizeof($current);
-        foreach ($current as $entry) {
+        
+		foreach ($current as $entry) {
           $output .= $entry->getHash();
           if (strlen($entry->getSalt()) > 0) {
-            $output .= "\t" . $entry->getSalt();
+            $salts = explode($hashlist->getSaltSeparator(), $entry->getSalt()); // Double salt
+			foreach ($salts as $salt) {
+			  $output .= "\t" . $salt;
+			}
           }
           $output .= $lineDelimiter;
         }

--- a/src/getHashlist.php
+++ b/src/getHashlist.php
@@ -70,7 +70,7 @@ switch ($format) {
         $output = "";
         $count += sizeof($current);
         
-		foreach ($current as $entry) {
+        foreach ($current as $entry) {
           $output .= $entry->getHash();
           if (strlen($entry->getSalt()) > 0) {
             $salts = explode($hashlist->getSaltSeparator(), $entry->getSalt()); // Double salt

--- a/src/getHashlist.php
+++ b/src/getHashlist.php
@@ -74,9 +74,9 @@ switch ($format) {
           $output .= $entry->getHash();
           if (strlen($entry->getSalt()) > 0) {
             $salts = explode($hashlist->getSaltSeparator(), $entry->getSalt()); // Double salt
-			foreach ($salts as $salt) {
-			  $output .= "\t" . $salt;
-			}
+            foreach ($salts as $salt) {
+              $output .= "\t" . $salt;
+            }
           }
           $output .= $lineDelimiter;
         }

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -236,6 +236,10 @@ class APISendProgress extends APIBasic {
             $plain = $splitLine[2]; // if hash is salted
             $crackPos = $splitLine[4];
           }
+          else if (sizeof($splitLine) == 6) { // Doulbe salt
+            $plain = $splitLine[3]; // if hash is salted
+            $crackPos = $splitLine[5];
+          }
           else {
             $plain = $splitLine[1];
             $crackPos = $splitLine[3];

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -1323,7 +1323,10 @@ class TaskUtils {
         "crackpos" => $entry->getCrackPos()
       ];
       if (strlen($entry->getSalt()) > 0) {
-        $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
+        $salts = explode($hashlist->getSaltSeparator(), $entry->getSalt()); // Double salt
+        foreach ($salts as $salt) {
+          $arr["hash"] .= $hashlist->getSaltSeparator() . $salt;
+        }
       }
       $hashes[] = $arr;
     }


### PR DESCRIPTION
These change render the possibility for one to run a task on hashes which are doubly-salted (e.g. hash mode 3730).