### PR TITLE
added multicolumn aggregation to DBA and improved three essential parts which suffer from many chunks

### DIFF
--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -34,7 +34,8 @@ abstract class HashtopolisTest {
     "0.13.0" => "c7036800be5b2e21542df0fa9bd4d19ebf7ecdf3",
     "0.13.1" => "fc4b5226c1d36dc0197f4d17d216298972055c09",
     "0.14.0" => "0af7193310c9c1f37a274578e159ab3ae0a6caad",
-    "0.14.1" => "375f2ce022c4b3e0780abf9dcca1e6af8e966c1a"
+    "0.14.1" => "375f2ce022c4b3e0780abf9dcca1e6af8e966c1a",
+    "0.14.2" => "d397e4b8ec1d2591b93fa44c8660edc314401da5"
   ];
   
   public function initAndUpgrade($fromVersion) {

--- a/src/dba/AbstractModelFactory.class.php
+++ b/src/dba/AbstractModelFactory.class.php
@@ -411,6 +411,31 @@ abstract class AbstractModelFactory {
     return $row['column_' . strtolower($op)];
   }
   
+  public function multicolAggregationFilter($options, $aggregations) {
+    //$options: as usual
+    //$columns: array of Aggregation objects
+    
+    $elements = [];
+    foreach ($aggregations as $aggregation) {
+      $elements[] = $aggregation->getQueryString();
+    }
+    
+    $query = "SELECT " . join(",", $elements);
+    $query = $query . " FROM " . $this->getModelTable();
+    
+    $vals = array();
+    
+    if (array_key_exists("filter", $options)) {
+      $query .= $this->applyFilters($vals, $options['filter']);
+    }
+    
+    $dbh = self::getDB();
+    $stmt = $dbh->prepare($query);
+    $stmt->execute($vals);
+    
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+  }
+  
   public function sumFilter($options, $sumColumn) {
     $query = "SELECT SUM($sumColumn) AS sum ";
     $query = $query . " FROM " . $this->getModelTable();

--- a/src/dba/Aggregation.class.php
+++ b/src/dba/Aggregation.class.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DBA;
+
+use DBA\AbstractModelFactory;
+
+class Aggregation {
+  private $column;
+  private $function;
+  /**
+   * @var AbstractModelFactory
+   */
+  private $factory;
+  
+  function __construct($column, $function, $factory = null) {
+    $this->column = $column;
+    $this->function = $function;
+    $this->factory = $factory;
+  }
+  
+  function getName() {
+    return strtolower($this->function) . "_" . $this->column;
+  }
+  
+  function getQueryString($table = "") {
+    if ($table != "") {
+      $table = $table . ".";
+    }
+    if ($this->factory != null) {
+      $table = $this->factory->getModelTable() . ".";
+    }
+    
+    return $this->function . "(" . $table . $this->column . ") AS " . $this->getName();
+  }
+}
+
+

--- a/src/dba/Aggregation.class.php
+++ b/src/dba/Aggregation.class.php
@@ -11,6 +11,11 @@ class Aggregation {
    * @var AbstractModelFactory
    */
   private $factory;
+
+  const SUM = "SUM";
+  const MAX = "MAX";
+  const MIN = "MIN";
+  const COUNT = "COUNT"; 
   
   function __construct($column, $function, $factory = null) {
     $this->column = $column;

--- a/src/dba/init.php
+++ b/src/dba/init.php
@@ -9,6 +9,7 @@ define("DBA_PORT", (isset($CONN['port'])) ? $CONN['port'] : "");
 
 require_once(dirname(__FILE__) . "/AbstractModel.class.php");
 require_once(dirname(__FILE__) . "/AbstractModelFactory.class.php");
+require_once(dirname(__FILE__) . "/Aggregation.class.php");
 require_once(dirname(__FILE__) . "/Filter.class.php");
 require_once(dirname(__FILE__) . "/Order.class.php");
 require_once(dirname(__FILE__) . "/Join.class.php");

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -1,5 +1,6 @@
 <?php
 
+use DBA\Aggregation;
 use DBA\AbstractModel;
 use DBA\AccessGroup;
 use DBA\AccessGroupUser;
@@ -377,33 +378,37 @@ class Util {
    * @return array
    */
   public static function getTaskInfo($task) {
-    $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-    $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
-    $progress = 0;
-    $cracked = 0;
-    $maxTime = 0;
-    $totalTimeSpent = 0;
-    $speed = 0;
-    foreach ($chunks as $chunk) {
-      if ($chunk->getDispatchTime() > 0 && $chunk->getSolveTime() > 0) {
-        $totalTimeSpent += $chunk->getSolveTime() - $chunk->getDispatchTime();
-      }
-      $progress += $chunk->getCheckpoint() - $chunk->getSkip();
-      $cracked += $chunk->getCracked();
-      if ($chunk->getDispatchTime() > $maxTime) {
-        $maxTime = $chunk->getDispatchTime();
-      }
-      if ($chunk->getSolveTime() > $maxTime) {
-        $maxTime = $chunk->getSolveTime();
-      }
-      $speed += $chunk->getSpeed();
-    }
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+    
+    $qF2 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
+    $qF3 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
+    $agg1 = new Aggregation(Chunk::SOLVE_TIME, "SUM");
+    $agg2 = new Aggregation(Chunk::DISPATCH_TIME, "SUM");
+    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);
+    
+    $totalTimeSpent = $results[$agg1->getName()] - $results[$agg2->getName()];
+    
+    $agg1 = new Aggregation(Chunk::CHECKPOINT, "SUM");
+    $agg2 = new Aggregation(Chunk::SKIP, "SUM");
+    $agg3 = new Aggregation(Chunk::CRACKED, "SUM");
+    $agg4 = new Aggregation(Chunk::SPEED, "SUM");
+    $agg5 = new Aggregation(Chunk::DISPATCH_TIME, "MAX");
+    $agg6 = new Aggregation(Chunk::SOLVE_TIME, "MAX");
+    $agg7 = new Aggregation(Chunk::CHUNK_ID, "COUNT");
+    
+    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => $qF1], [$agg1, $agg2, $agg3, $agg4, $agg5, $agg6, $agg7]);
+    
+    $progress = $results[$agg1->getName()] - $results[$agg2->getName()];
+    $cracked = $results[$agg3->getName()];
+    $speed = $results[$agg4->getName()];
+    $maxTime = max($results[$agg5->getName()], $results[$agg6->getName()]);
+    $numChunks = $results[$agg7->getName()];
     
     $isActive = false;
     if (time() - $maxTime < SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT) && ($progress < $task->getKeyspace() || $task->getUsePreprocessor() && $task->getKeyspace() == DPrince::PRINCE_KEYSPACE)) {
       $isActive = true;
     }
-    return array($progress, $cracked, $isActive, sizeof($chunks), ($totalTimeSpent > 0) ? round($cracked * 60 / $totalTimeSpent, 2) : 0, $speed);
+    return array($progress, $cracked, $isActive, $numChunks, ($totalTimeSpent > 0) ? round($cracked * 60 / $totalTimeSpent, 2) : 0, $speed);
   }
   
   /**
@@ -438,8 +443,12 @@ class Util {
    */
   public static function getChunkInfo($task) {
     $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-    $cracked = Factory::getChunkFactory()->sumFilter([Factory::FILTER => $qF], Chunk::CRACKED);
-    $numChunks = Factory::getChunkFactory()->countFilter([Factory::FILTER => $qF]);
+    $agg1 = new Aggregation(Chunk::CRACKED, "SUM");
+    $agg2 = new Aggregation(Chunk::CHUNK_ID, "COUNT");
+    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => $qF], [$agg1, $agg2]);
+    
+    $cracked = $results[$agg1->getName()];
+    $numChunks = $results[$agg2->getName()];
     
     $qF = new QueryFilter(Assignment::TASK_ID, $task->getId(), "=");
     $numAssignments = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -380,23 +380,19 @@ class Util {
   public static function getTaskInfo($task) {
     $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     
-    $qF2 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
-    $qF3 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
-    $agg1 = new Aggregation(Chunk::SOLVE_TIME, "SUM");
-    $agg2 = new Aggregation(Chunk::DISPATCH_TIME, "SUM");
-    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);
+    $agg1 = new Aggregation(Chunk::CHECKPOINT, Aggregation::SUM);
+    $agg2 = new Aggregation(Chunk::SKIP, Aggregation::SUM);
+    $agg3 = new Aggregation(Chunk::CRACKED, Aggregation::SUM);
+    $agg4 = new Aggregation(Chunk::SPEED, Aggregation::SUM);
+    $agg5 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::MAX);
+    $agg6 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::MAX);
+    $agg7 = new Aggregation(Chunk::CHUNK_ID, Aggregation::COUNT);
+    $agg8 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::SUM);
+    $agg9 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::SUM);
     
-    $totalTimeSpent = $results[$agg1->getName()] - $results[$agg2->getName()];
+    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => $qF1], [$agg1, $agg2, $agg3, $agg4, $agg5, $agg6, $agg7, $agg8, $agg9]);
     
-    $agg1 = new Aggregation(Chunk::CHECKPOINT, "SUM");
-    $agg2 = new Aggregation(Chunk::SKIP, "SUM");
-    $agg3 = new Aggregation(Chunk::CRACKED, "SUM");
-    $agg4 = new Aggregation(Chunk::SPEED, "SUM");
-    $agg5 = new Aggregation(Chunk::DISPATCH_TIME, "MAX");
-    $agg6 = new Aggregation(Chunk::SOLVE_TIME, "MAX");
-    $agg7 = new Aggregation(Chunk::CHUNK_ID, "COUNT");
-    
-    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => $qF1], [$agg1, $agg2, $agg3, $agg4, $agg5, $agg6, $agg7]);
+    $totalTimeSpent = $results[$agg8->getName()] - $results[$agg9->getName()];
     
     $progress = $results[$agg1->getName()] - $results[$agg2->getName()];
     $cracked = $results[$agg3->getName()];

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -1154,18 +1154,20 @@ class TaskUtils {
     else if ($task->getUsePreprocessor() && $task->getKeyspace() == DPrince::PRINCE_KEYSPACE) {
       return $task;
     }
+
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, ">=");
+    $sum = Factory::getChunkFactory()->sumFilter([Factory::FILTER => [$qF1, $qF2]], Chunk::LENGTH);
+
+    $dispatched = $task->getSkipKeyspace() + $sum;
+    $completed = $task->getSkipKeyspace() + $sum;
     
     // check chunks
-    $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-    $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
-    $dispatched = $task->getSkipKeyspace();
-    $completed = $task->getSkipKeyspace();
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+    $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
     foreach ($chunks as $chunk) {
-      if ($chunk->getProgress() >= 10000) {
-        $dispatched += $chunk->getLength();
-        $completed += $chunk->getLength();
-      }
-      else if ($chunk->getAgentId() == null) {
+      if ($chunk->getAgentId() == null) {
         return $task; // at least one chunk is not assigned
       }
       else if (time() - max($chunk->getSolveTime(), $chunk->getDispatchTime()) > SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT)) {


### PR DESCRIPTION
This PR solves some of the issues with loading/handling of systems with large amount of tasks or larger number of agents:

- When creating chunks, so far there was a global lock file in place which was locked no matter for which task a chunk was about to be created. It is enough to lock by each task, as creating two chunks for two different tasks at the same time poses no problem.
- When having active tasks with very large amount of chunks, the chunk assignment on the server may take so long, that the agent thinks the connection has timed out (30s). This can lead to situations where all agents end up in the loop of requesting chunks/tasks and the server is not able to respond fast enough anymore due to an active task it has to check where it looped over all chunks (which obviously took time the larger the number of chunks). This is solved by the changes in TaskUtils where instead of looping over all existing chunks, it is only looping over the non-completed ones and uses SUM in sql to determine the other needed values.
- In general there are a lot of places in the code, where multiple queries are done summing/counting/maxing over columns (or even worse, in most of the places, the entries are loaded and looped over in the code). When having a lot of chunks, the biggest issue happened in the getTaskInfo() function, which is used by the current old UI, causing very long loading times of the tasks page if tasks with many chunks were listed. In order to tackle this, the DBA was extended slightly to be able to sum/count/max/.. over multiple columns with the same query (as long as the where conditions were the same for all them). In the specific case of the getTaskInfo() function, this reduced the loading times by 5-6 times approximately.

The DBA function change was already adapted for the getChunkInfo() function as well, but there may be many places still around where potentially using either a aggregation function alone or using the newly added multicolumn aggregation could give potential additional speedups.