### PR TITLE
Ipv6 support in buildServerUrl()

### DIFF
--- a/ci/HashtopolisTest.class.php
+++ b/ci/HashtopolisTest.class.php
@@ -34,7 +34,8 @@ abstract class HashtopolisTest {
     "0.13.0" => "c7036800be5b2e21542df0fa9bd4d19ebf7ecdf3",
     "0.13.1" => "fc4b5226c1d36dc0197f4d17d216298972055c09",
     "0.14.0" => "0af7193310c9c1f37a274578e159ab3ae0a6caad",
-    "0.14.1" => "375f2ce022c4b3e0780abf9dcca1e6af8e966c1a"
+    "0.14.1" => "375f2ce022c4b3e0780abf9dcca1e6af8e966c1a",
+    "0.14.2" => "d397e4b8ec1d2591b93fa44c8660edc314401da5"
   ];
   
   public function initAndUpgrade($fromVersion) {

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -1148,14 +1148,13 @@ class Util {
     $protocol = (isset($_SERVER['HTTPS']) && (strcasecmp('off', $_SERVER['HTTPS']) !== 0)) ? "https://" : "http://";
     $hostname = $_SERVER['HTTP_HOST'];
     $port = $_SERVER['SERVER_PORT'];
-    if (strpos($hostname, ":") !== false) {
-      $hostname = substr($hostname, 0, strpos($hostname, ":"));
-    }
+
     if ($protocol == "https://" && $port == 443 || $protocol == "http://" && $port == 80) {
       $port = "";
     }
     else {
       $port = ":$port";
+      $hostname = substr($hostname, 0, strrpos($hostname, ":")); //Needs to use strrpos in case of ipv6 because of multiple ':' characters
     }
     return $protocol . $hostname . $port;
   }


### PR DESCRIPTION
fixes #725 

The current code didn't work in case of an ipv6 address. This is because the host name got parsed by using strpos($hostname, ":"). this goes perfectly fine for an ipv4 address. But when you have an ipv6 address that already contains multiple ":" characters this goes wrong. For example http://[201:a373:f940:2421:b2f2:6a91:86b7:5628]/api/server.php would become http://[201/api/server.php. I fixed it by using strrpos when the server is not at port 80 or 433. This way the last occurrence of ":" will be used which splits the hostname of the port.