### PR TITLE
1096 enhancement increase the limit of the attack command length

### DIFF
--- a/src/dba/models/HealthCheck.class.php
+++ b/src/dba/models/HealthCheck.class.php
@@ -46,7 +46,7 @@ class HealthCheck extends AbstractModel {
     $dict['hashtypeId'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "hashtypeId"];
     $dict['crackerBinaryId'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "crackerBinaryId"];
     $dict['expectedCracks'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "expectedCracks"];
-    $dict['attackCmd'] = ['read_only' => True, "type" => "str(256)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => True, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "attackCmd"];
 
     return $dict;
   }

--- a/src/dba/models/HealthCheck.class.php
+++ b/src/dba/models/HealthCheck.class.php
@@ -46,7 +46,7 @@ class HealthCheck extends AbstractModel {
     $dict['hashtypeId'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "hashtypeId"];
     $dict['crackerBinaryId'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "crackerBinaryId"];
     $dict['expectedCracks'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "expectedCracks"];
-    $dict['attackCmd'] = ['read_only' => True, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => True, "type" => "str(16384)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "attackCmd"];
 
     return $dict;
   }

--- a/src/dba/models/Pretask.class.php
+++ b/src/dba/models/Pretask.class.php
@@ -56,7 +56,7 @@ class Pretask extends AbstractModel {
     $dict = array();
     $dict['pretaskId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => True, "protected" => True, "private" => False, "alias" => "pretaskId"];
     $dict['taskName'] = ['read_only' => False, "type" => "str(100)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskName"];
-    $dict['attackCmd'] = ['read_only' => False, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => False, "type" => "str(16384)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
     $dict['chunkTime'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "chunkTime"];
     $dict['statusTimer'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "statusTimer"];
     $dict['color'] = ['read_only' => False, "type" => "str(20)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "color"];

--- a/src/dba/models/Pretask.class.php
+++ b/src/dba/models/Pretask.class.php
@@ -56,7 +56,7 @@ class Pretask extends AbstractModel {
     $dict = array();
     $dict['pretaskId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => True, "protected" => True, "private" => False, "alias" => "pretaskId"];
     $dict['taskName'] = ['read_only' => False, "type" => "str(100)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskName"];
-    $dict['attackCmd'] = ['read_only' => False, "type" => "str(256)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => False, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
     $dict['chunkTime'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "chunkTime"];
     $dict['statusTimer'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "statusTimer"];
     $dict['color'] = ['read_only' => False, "type" => "str(20)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "color"];

--- a/src/dba/models/Task.class.php
+++ b/src/dba/models/Task.class.php
@@ -89,7 +89,7 @@ class Task extends AbstractModel {
     $dict = array();
     $dict['taskId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => True, "protected" => True, "private" => False, "alias" => "taskId"];
     $dict['taskName'] = ['read_only' => False, "type" => "str(256)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskName"];
-    $dict['attackCmd'] = ['read_only' => False, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => False, "type" => "str(16384)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
     $dict['chunkTime'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "chunkTime"];
     $dict['statusTimer'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "statusTimer"];
     $dict['keyspace'] = ['read_only' => True, "type" => "int64", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "keyspace"];

--- a/src/dba/models/Task.class.php
+++ b/src/dba/models/Task.class.php
@@ -89,7 +89,7 @@ class Task extends AbstractModel {
     $dict = array();
     $dict['taskId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => True, "protected" => True, "private" => False, "alias" => "taskId"];
     $dict['taskName'] = ['read_only' => False, "type" => "str(256)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskName"];
-    $dict['attackCmd'] = ['read_only' => False, "type" => "str(256)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
+    $dict['attackCmd'] = ['read_only' => False, "type" => "str(65535)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "attackCmd"];
     $dict['chunkTime'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "chunkTime"];
     $dict['statusTimer'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "statusTimer"];
     $dict['keyspace'] = ['read_only' => True, "type" => "int64", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "keyspace"];

--- a/src/dba/models/generator.php
+++ b/src/dba/models/generator.php
@@ -267,7 +267,7 @@ $CONF['HealthCheck'] = [
     ['name' => 'hashtypeId', 'read_only' => False, 'type' => 'int'],
     ['name' => 'crackerBinaryId', 'read_only' => False, 'type' => 'int'],
     ['name' => 'expectedCracks', 'read_only' => True, 'type' => 'int', 'protected' => True],
-    ['name' => 'attackCmd', 'read_only' => True, 'type' => 'str(256)', 'protected' => True],
+    ['name' => 'attackCmd', 'read_only' => True, 'type' => 'str(65535)', 'protected' => True],
   ],
 ];
 $CONF['HealthCheckAgent'] = [
@@ -319,7 +319,7 @@ $CONF['Pretask'] = [
   'columns' => [
     ['name' => 'pretaskId', 'read_only' => True, 'type' => 'int', 'protected' => True],
     ['name' => 'taskName', 'read_only' => False, 'type' => 'str(100)'],
-    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(256)'],
+    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(65535)'],
     ['name' => 'chunkTime', 'read_only' => False, 'type' => 'int'],
     ['name' => 'statusTimer', 'read_only' => False, 'type' => 'int'],
     ['name' => 'color', 'read_only' => False, 'type' => 'str(20)'],
@@ -382,7 +382,7 @@ $CONF['Task'] = [
   'columns' => [
     ['name' => 'taskId', 'read_only' => True, 'type' => 'int', 'protected' => True],
     ['name' => 'taskName', 'read_only' => False, 'type' => 'str(256)'],
-    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(256)'],
+    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(65535)'],
     ['name' => 'chunkTime', 'read_only' => False, 'type' => 'int'],
     ['name' => 'statusTimer', 'read_only' => False, 'type' => 'int'],
     ['name' => 'keyspace', 'read_only' => True, 'type' => 'int64', 'protected' => True],

--- a/src/dba/models/generator.php
+++ b/src/dba/models/generator.php
@@ -267,7 +267,7 @@ $CONF['HealthCheck'] = [
     ['name' => 'hashtypeId', 'read_only' => False, 'type' => 'int'],
     ['name' => 'crackerBinaryId', 'read_only' => False, 'type' => 'int'],
     ['name' => 'expectedCracks', 'read_only' => True, 'type' => 'int', 'protected' => True],
-    ['name' => 'attackCmd', 'read_only' => True, 'type' => 'str(65535)', 'protected' => True],
+    ['name' => 'attackCmd', 'read_only' => True, 'type' => 'str(16384)', 'protected' => True],
   ],
 ];
 $CONF['HealthCheckAgent'] = [
@@ -319,7 +319,7 @@ $CONF['Pretask'] = [
   'columns' => [
     ['name' => 'pretaskId', 'read_only' => True, 'type' => 'int', 'protected' => True],
     ['name' => 'taskName', 'read_only' => False, 'type' => 'str(100)'],
-    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(65535)'],
+    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(16384)'],
     ['name' => 'chunkTime', 'read_only' => False, 'type' => 'int'],
     ['name' => 'statusTimer', 'read_only' => False, 'type' => 'int'],
     ['name' => 'color', 'read_only' => False, 'type' => 'str(20)'],
@@ -382,7 +382,7 @@ $CONF['Task'] = [
   'columns' => [
     ['name' => 'taskId', 'read_only' => True, 'type' => 'int', 'protected' => True],
     ['name' => 'taskName', 'read_only' => False, 'type' => 'str(256)'],
-    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(65535)'],
+    ['name' => 'attackCmd', 'read_only' => False, 'type' => 'str(16384)'],
     ['name' => 'chunkTime', 'read_only' => False, 'type' => 'int'],
     ['name' => 'statusTimer', 'read_only' => False, 'type' => 'int'],
     ['name' => 'keyspace', 'read_only' => True, 'type' => 'int64', 'protected' => True],

--- a/src/inc/info.php
+++ b/src/inc/info.php
@@ -1,6 +1,6 @@
 <?php
 
-$VERSION = "0.14.2";
+$VERSION = "0.14.3";
 $BUILD = "repository";
 $HOST = @$_SERVER['HTTP_HOST'];
 if (strpos($HOST, ":") !== false) {

--- a/src/inc/utils/PretaskUtils.class.php
+++ b/src/inc/utils/PretaskUtils.class.php
@@ -305,8 +305,8 @@ class PretaskUtils {
     else if (strpos($cmdLine, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
       throw new HTException("The attack command does not contain the hashlist alias!");
     }
-    else if (strlen($cmdLine) > 256) {
-      throw new HTException("Attack command is too long (max 256 characters)!");
+    else if (strlen($cmdLine) > 65535) {
+      throw new HTException("Attack command is too long (max 65535 characters)!");
     }
     else if (Util::containsBlacklistedChars($cmdLine)) {
       throw new HTException("The command must contain no blacklisted characters!");

--- a/src/inc/utils/PretaskUtils.class.php
+++ b/src/inc/utils/PretaskUtils.class.php
@@ -305,8 +305,8 @@ class PretaskUtils {
     else if (strpos($cmdLine, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
       throw new HTException("The attack command does not contain the hashlist alias!");
     }
-    else if (strlen($cmdLine) > 65535) {
-      throw new HTException("Attack command is too long (max 65535 characters)!");
+    else if (strlen($cmdLine) > 16384) {
+      throw new HTException("Attack command is too long (max 16384 characters)!");
     }
     else if (Util::containsBlacklistedChars($cmdLine)) {
       throw new HTException("The command must contain no blacklisted characters!");

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -763,8 +763,8 @@ class TaskUtils {
     else if (strpos($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
       throw new HTException("Attack command does not contain hashlist alias!");
     }
-    else if (strlen($attackCmd) > 65535) {
-      throw new HTException("Attack command is too long (max 65535 characters)!");
+    else if (strlen($attackCmd) > 16384) {
+      throw new HTException("Attack command is too long (max 16384 characters)!");
     }
     else if ($staticChunking < DTaskStaticChunking::NORMAL || $staticChunking > DTaskStaticChunking::NUM_CHUNKS) {
       throw new HTException("Invalid static chunk setting!");

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -763,8 +763,8 @@ class TaskUtils {
     else if (strpos($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
       throw new HTException("Attack command does not contain hashlist alias!");
     }
-    else if (strlen($attackCmd) > 256) {
-      throw new HTException("Attack command is too long (max 256 characters)!");
+    else if (strlen($attackCmd) > 65535) {
+      throw new HTException("Attack command is too long (max 65535 characters)!");
     }
     else if ($staticChunking < DTaskStaticChunking::NORMAL || $staticChunking > DTaskStaticChunking::NUM_CHUNKS) {
       throw new HTException("Invalid static chunk setting!");

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -786,7 +786,7 @@ CREATE TABLE `NotificationSetting` (
 CREATE TABLE `Pretask` (
   `pretaskId`           INT(11)      NOT NULL,
   `taskName`            VARCHAR(100) NOT NULL,
-  `attackCmd`           VARCHAR(65535) NOT NULL,
+  `attackCmd`           VARCHAR(16384) NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `color`               VARCHAR(20)  NULL,
@@ -851,7 +851,7 @@ CREATE TABLE `SupertaskPretask` (
 CREATE TABLE `Task` (
   `taskId`              INT(11)      NOT NULL,
   `taskName`            VARCHAR(256) NOT NULL,
-  `attackCmd`           VARCHAR(65535) NOT NULL,
+  `attackCmd`           VARCHAR(16384) NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `keyspace`            BIGINT(20)   NOT NULL,
@@ -954,7 +954,7 @@ CREATE TABLE `HealthCheck` (
   `hashtypeId`      INT(11)      NOT NULL,
   `crackerBinaryId` INT(11)      NOT NULL,
   `expectedCracks`  INT(11)      NOT NULL,
-  `attackCmd`       VARCHAR(65535) NOT NULL
+  `attackCmd`       VARCHAR(16384) NOT NULL
 ) ENGINE=InnoDB;
 
 CREATE TABLE `HealthCheckAgent` (

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -786,7 +786,7 @@ CREATE TABLE `NotificationSetting` (
 CREATE TABLE `Pretask` (
   `pretaskId`           INT(11)      NOT NULL,
   `taskName`            VARCHAR(100) NOT NULL,
-  `attackCmd`           VARCHAR(16384) NOT NULL,
+  `attackCmd`           TEXT         NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `color`               VARCHAR(20)  NULL,
@@ -851,7 +851,7 @@ CREATE TABLE `SupertaskPretask` (
 CREATE TABLE `Task` (
   `taskId`              INT(11)      NOT NULL,
   `taskName`            VARCHAR(256) NOT NULL,
-  `attackCmd`           VARCHAR(16384) NOT NULL,
+  `attackCmd`           TEXT         NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `keyspace`            BIGINT(20)   NOT NULL,
@@ -954,7 +954,7 @@ CREATE TABLE `HealthCheck` (
   `hashtypeId`      INT(11)      NOT NULL,
   `crackerBinaryId` INT(11)      NOT NULL,
   `expectedCracks`  INT(11)      NOT NULL,
-  `attackCmd`       VARCHAR(16384) NOT NULL
+  `attackCmd`       TEXT         NOT NULL
 ) ENGINE=InnoDB;
 
 CREATE TABLE `HealthCheckAgent` (

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -786,7 +786,7 @@ CREATE TABLE `NotificationSetting` (
 CREATE TABLE `Pretask` (
   `pretaskId`           INT(11)      NOT NULL,
   `taskName`            VARCHAR(100) NOT NULL,
-  `attackCmd`           VARCHAR(256) NOT NULL,
+  `attackCmd`           VARCHAR(65535) NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `color`               VARCHAR(20)  NULL,
@@ -851,7 +851,7 @@ CREATE TABLE `SupertaskPretask` (
 CREATE TABLE `Task` (
   `taskId`              INT(11)      NOT NULL,
   `taskName`            VARCHAR(256) NOT NULL,
-  `attackCmd`           VARCHAR(256) NOT NULL,
+  `attackCmd`           VARCHAR(65535) NOT NULL,
   `chunkTime`           INT(11)      NOT NULL,
   `statusTimer`         INT(11)      NOT NULL,
   `keyspace`            BIGINT(20)   NOT NULL,
@@ -954,7 +954,7 @@ CREATE TABLE `HealthCheck` (
   `hashtypeId`      INT(11)      NOT NULL,
   `crackerBinaryId` INT(11)      NOT NULL,
   `expectedCracks`  INT(11)      NOT NULL,
-  `attackCmd`       VARCHAR(256) NOT NULL
+  `attackCmd`       VARCHAR(65535) NOT NULL
 ) ENGINE=InnoDB;
 
 CREATE TABLE `HealthCheckAgent` (

--- a/src/install/updates/update_v0.14.x_v0.14.3.php
+++ b/src/install/updates/update_v0.14.x_v0.14.3.php
@@ -15,3 +15,11 @@ if (!isset($PRESENT["v0.14.x_agentBinaries"])) {
   Util::checkAgentVersion("python", "0.7.2", true);
   $EXECUTED["v0.14.x_agentBinaries"] = true;
 }
+
+
+if (!isset($PRESENT["v0.14.x_attackCmd"])) {
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Task` MODIFY `attackCmd` mediumtext;");
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Pretask` MODIFY `attackCmd` mediumtext;");
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `HealthCheck` MODIFY `attackCmd` mediumtext;");
+  $EXECUTED["v0.14.x_attackCmd"] = true;
+}

--- a/src/install/updates/update_v0.14.x_v0.14.3.php
+++ b/src/install/updates/update_v0.14.x_v0.14.3.php
@@ -18,8 +18,8 @@ if (!isset($PRESENT["v0.14.x_agentBinaries"])) {
 
 
 if (!isset($PRESENT["v0.14.x_attackCmd"])) {
-  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Task` MODIFY `attackCmd` mediumtext;");
-  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Pretask` MODIFY `attackCmd` mediumtext;");
-  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `HealthCheck` MODIFY `attackCmd` mediumtext;");
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Task` MODIFY `attackCmd` TEXT NOT NULL;");
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `Pretask` MODIFY `attackCmd` TEXT NOT NULL;");
+  Factory::getAgentFactory()->getDB()->query("ALTER TABLE `HealthCheck` MODIFY `attackCmd` TEXT NOT NULL;");
   $EXECUTED["v0.14.x_attackCmd"] = true;
 }


### PR DESCRIPTION
Sorry for the confusion on some commits, I think I'm finally done with my first PR ;-)
The DB fields attackCmd in HealthCheck, PreTask and Task are now changed to TEXT, frontend limit is set to a string length of 16.386, we think that should be enough.
I have changed the hashtopolis.sql for a fresh installation and I've created a new version 0.14.3 including an update_xxx-php, both worked in our tests.
If I missed something or made something wrong, please let me know.