### PR TITLE
FIX: fix issue where hashes that are in binary format do not get thei…

### DIFF
--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -1130,35 +1130,23 @@ class HashlistUtils {
     if (!AccessUtils::userCanAccessHashlists($lists, $user)) {
       throw new HTException("No access to the hashlists!");
     }
-    
     $hashlistIds = Util::arrayOfIds($lists);
     $qF1 = new ContainFilter(Hash::HASHLIST_ID, $hashlistIds);
     $qF2 = new QueryFilter(Hash::IS_CRACKED, 1, "=");
     $hashes = [];
-    $format = Factory::getHashlistFactory()->get($hashlistId);
-    if ($format->getFormat() != 0) {
-      $entries_binary = Factory::getHashBinaryFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-      foreach ($entries_binary as $entry) {
-        $arr = [
-          "hash" => $entry->getHash(),
-          "plain" => $entry->getPlaintext(),
-          "crackpos" => $entry->getCrackPos()
-        ];
-        $hashes[] = $arr;
+    $isBinary = $hashlist->getFormat() != 0;
+    $factory = $isBinary ? Factory::getHashBinaryFactory() : Factory::getHashFactory();
+    $entries = $factory->filter([Factory::FILTER => [$qF1, $qF2]]);
+    foreach ($entries as $entry) {
+      $arr = [
+        "hash" => $entry->getHash(),
+        "plain" => $entry->getPlaintext(),
+        "crackpos" => $entry->getCrackPos()
+      ];
+      if ($hashlist->getIsSalted()) {
+        $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
       }
-    } else {
-      $entries = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-      foreach ($entries as $entry) {
-        $arr = [
-          "hash" => $entry->getHash(),
-          "plain" => $entry->getPlaintext(),
-          "crackpos" => $entry->getCrackPos()
-        ];
-        if (strlen($entry->getSalt()) > 0) {
-          $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
-        }
-        $hashes[] = $arr;
-      }
+      $hashes[] = $arr;
     }
     return $hashes;
   }

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -1135,26 +1135,30 @@ class HashlistUtils {
     $qF1 = new ContainFilter(Hash::HASHLIST_ID, $hashlistIds);
     $qF2 = new QueryFilter(Hash::IS_CRACKED, 1, "=");
     $hashes = [];
-    $entries = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-    foreach ($entries as $entry) {
-      $arr = [
-        "hash" => $entry->getHash(),
-        "plain" => $entry->getPlaintext(),
-        "crackpos" => $entry->getCrackPos()
-      ];
-      if (strlen($entry->getSalt()) > 0) {
-        $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
+    $format = Factory::getHashlistFactory()->get($hashlistId);
+    if ($format->getFormat() != 0) {
+      $entries_binary = Factory::getHashBinaryFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+      foreach ($entries_binary as $entry) {
+        $arr = [
+          "hash" => $entry->getHash(),
+          "plain" => $entry->getPlaintext(),
+          "crackpos" => $entry->getCrackPos()
+        ];
+        $hashes[] = $arr;
       }
-      $hashes[] = $arr;
-    }
-    $entries_binary = Factory::getHashBinaryFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-    foreach ($entries_binary as $entry) {
-      $arr = [
-        "hash" => $entry->getHash(),
-        "plain" => $entry->getPlaintext(),
-        "crackpos" => $entry->getCrackPos()
-      ];
-      $hashes[] = $arr;
+    } else {
+      $entries = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+      foreach ($entries as $entry) {
+        $arr = [
+          "hash" => $entry->getHash(),
+          "plain" => $entry->getPlaintext(),
+          "crackpos" => $entry->getCrackPos()
+        ];
+        if (strlen($entry->getSalt()) > 0) {
+          $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
+        }
+        $hashes[] = $arr;
+      }
     }
     return $hashes;
   }

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -1147,6 +1147,15 @@ class HashlistUtils {
       }
       $hashes[] = $arr;
     }
+    $entries_binary = Factory::getHashBinaryFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+    foreach ($entries_binary as $entry) {
+      $arr = [
+        "hash" => $entry->getHash(),
+        "plain" => $entry->getPlaintext(),
+        "crackpos" => $entry->getCrackPos()
+      ];
+      $hashes[] = $arr;
+    }
     return $hashes;
   }
   

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -1144,7 +1144,9 @@ class HashlistUtils {
         "crackpos" => $entry->getCrackPos()
       ];
       if ($hashlist->getIsSalted()) {
-        $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
+        if (strlen($entry->getSalt()) > 0) {
+          $arr["hash"] .= $hashlist->getSaltSeparator() . $entry->getSalt();
+        }
       }
       $hashes[] = $arr;
     }


### PR DESCRIPTION
_…r_ cracked plaintext returned through the api. 

Is able to return information by including in the HashBinary factory in the GetCracked function. Helps address issue #1101 