### PR TITLE
1094 setting up phpstorm for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,6 @@
   ],
   "workspaceFolder": "/var/www/html",
   "customizations": {
-    "jetbrains" : {
-      "settings" : {
-        "Docker:app:DockerSettings.dockerComposePath" : "/usr/bin/docker",
-        "Docker:app:DockerSettings.dockerPath" : "/usr/bin/docker"
-      }
-    },
     "vscode": {
       "extensions": [
         "xdebug.php-debug",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,12 @@
   ],
   "workspaceFolder": "/var/www/html",
   "customizations": {
+    "jetbrains" : {
+      "settings" : {
+        "Docker:app:DockerSettings.dockerComposePath" : "/usr/bin/docker",
+        "Docker:app:DockerSettings.dockerPath" : "/usr/bin/docker"
+      }
+    },
     "vscode": {
       "extensions": [
         "xdebug.php-debug",
@@ -53,5 +59,6 @@
     "NODE_OPTIONS": "--use-openssl-ca"
   },
   "remoteUser": "vscode",
+  "overrideCommand": false,
   "postStartCommand": "composer install --working-dir=/var/www/html/"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,11 +93,13 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 FROM hashtopolis-server-base as hashtopolis-server-dev
 
 # Setting up development requirements, install xdebug
-RUN yes | pecl install xdebug \
+RUN yes | pecl install xdebug && docker-php-ext-enable xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.client_host = localhost" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/xdebug.ini \
     \
     # Configuring PHP
     && touch "/usr/local/etc/php/conf.d/custom.ini" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,6 @@ RUN yes | pecl install xdebug && docker-php-ext-enable xdebug \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
-	&& echo "xdebug.client_host = localhost" >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/xdebug.ini \
     \
     # Configuring PHP


### PR DESCRIPTION
- devcontainer support for PHPStorm added in devcontainer.json, the only problem was, that Apache did not start
- additional php debug extension and xdebug.ini setting added do docker build process