### PR TITLE
FIXED error for unsupported php 8.4 in xdebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 FROM hashtopolis-server-base as hashtopolis-server-dev
 
 # Setting up development requirements, install xdebug
-RUN yes | pecl install xdebug && docker-php-ext-enable xdebug \
+RUN yes | pecl install xdebug-3.4.0beta1 && docker-php-ext-enable xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \

--- a/src/api/v2/index.php
+++ b/src/api/v2/index.php
@@ -7,7 +7,7 @@ if (!$enabled || $enabled == 'false') {
 }
 
 date_default_timezone_set("UTC");
-error_reporting(E_ALL);
+error_reporting(E_ALL ^ E_DEPRECATED);
 ini_set("display_errors", '1');
 /**
  * Treat warnings as error, very usefull during unit testing.


### PR DESCRIPTION
temporarily fix by upgrading xdebug to version 3.4.0beta1. When stable release of xdebug supports php version 8.4 we should change this line again.

Second part of the fix is to disable deprecation warning as errors in the apiv2 backend. php 8.4 introduces some deprecations (https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). By throwing this as hard errors, the ci/cd pipeline fails so I had to disable it.