### PR TITLE
Changed to xdebug stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENTRYPOINT [ "docker-entrypoint.sh" ]
 FROM hashtopolis-server-base as hashtopolis-server-dev
 
 # Setting up development requirements, install xdebug
-RUN yes | pecl install xdebug-3.4.0beta1 && docker-php-ext-enable xdebug \
+RUN yes | pecl install xdebug && docker-php-ext-enable xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \


### PR DESCRIPTION
Now that xdebug stable release supports the latest php version we can use that again.