### PR TITLE
1139 enhancement cleanup lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ src/files/*
 *.phpproj
 *.sln
 *.phpproj.user
-*.lock
+*.lock*
 
 # dynamically created by installer
 src/install/.htaccess

--- a/src/inc/utils/LockUtils.class.php
+++ b/src/inc/utils/LockUtils.class.php
@@ -41,4 +41,18 @@ class LockUtils {
       }
     }
   }
+
+  /**
+   * Deletes a lock file associated with a specific task ID if it exists.
+   * 
+   * @param int $taskId The unique identifier of the task associated with the lock file.
+   * 
+   * @return void
+   */
+  public static function deleteLockFile($taskId) {
+    $lockFile = dirname(__FILE__) . "/locks/" . LOCK::CHUNKING . $taskId;
+    if(file_exists($lockFile)) {
+      unlink($lockFile);
+    }
+  }
 }

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -1114,6 +1114,7 @@ class TaskUtils {
     $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     Factory::getChunkFactory()->massDeletion([Factory::FILTER => $qF]);
     Factory::getTaskFactory()->delete($task);
+    LockUtils::deleteLockFile($task->getId());
   }
   
   /**
@@ -1188,6 +1189,7 @@ class TaskUtils {
       if ($taskWrapper->getTaskType() != DTaskTypes::SUPERTASK) {
         Factory::getTaskWrapperFactory()->set($taskWrapper, TaskWrapper::PRIORITY, 0);
       }
+      LockUtils::deleteLockFile($task->getId());
       return null;
     }
     else if ($dispatched >= $task->getKeyspace()) {


### PR DESCRIPTION
Fixes #1139. Added the new format of the lock files to the .gitignore and also removes the lockfile when the relevant task is deleted or finished.