### PR TITLE
Write cracked hashes to log that have been skipped

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
 ## Enhancements
 
 - Use utf8mb4 as default encoding in order to support the full unicode range
+- Log hashes when they are skipped. This way the administrator can detect when Hashcat rebuilds the hashes incorrectly 
 
 ## Bugfixes
 

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -231,9 +231,9 @@ class APISendProgress extends APIBasic {
           if (sizeof($hashes) == 0) {
             //This can happen if agent rebuild the hash incorrectly
             //Log the skipped hash so that admin can spot this false negative
-            $logMessage = "Hash has been cracked but skipped! This happened while cracking hashlist with Id: "
-              . $hashlist->getId() . " during chunk with id: " . $chunk->getId() . " This happens when the agent returns
-               a cracked hash that Does not exist in the database. This can happen when hashcat malforms the hash";
+            $logMessage = "Hash has been cracked but skipped! This happened while cracking hashlist with ID: "
+              . $hashlist->getId() . " during chunk with ID: " . $chunk->getId() . " This happens when the agent returns
+               a cracked hash that does not exist in the database. This can happen when hashcat malforms the hash.";
             Util::createLogEntry(DLogEntryIssuer::API, $this->agent->getToken(), DLogEntry::FATAL, $logMessage);
             DServerLog::log(DServerLog::FATAL, $logMessage);
 

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -229,6 +229,12 @@ class APISendProgress extends APIBasic {
           $qF3 = new QueryFilter(Hash::IS_CRACKED, 0, "=");
           $hashes = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3]]);
           if (sizeof($hashes) == 0) {
+            //This can happen if agent rebuild the hash incorrectly
+            //Log the skipped hash so that admin can spot this false negative
+            $logMessage = "Hash: " . $splitLine[0] . "has been cracked but skipped! The crack: " . $splitLine[1];
+            Util::createLogEntry(DLogEntryIssuer::API, $this->agent->getToken(), DLogEntry::FATAL, $logMessage);
+            DServerLog::log(DServerLog::FATAL, $logMessage);
+
             $skipped++;
             break;
           }

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -231,7 +231,9 @@ class APISendProgress extends APIBasic {
           if (sizeof($hashes) == 0) {
             //This can happen if agent rebuild the hash incorrectly
             //Log the skipped hash so that admin can spot this false negative
-            $logMessage = "Hash: " . $splitLine[0] . "has been cracked but skipped! The crack: " . $splitLine[1];
+            $logMessage = "Hash has been cracked but skipped! This happened while cracking hashlist with Id: "
+              . $hashlist->getId() . " during chunk with id: " . $chunk->getId() . " This happens when the agent returns
+               a cracked hash that Does not exist in the database. This can happen when hashcat malforms the hash";
             Util::createLogEntry(DLogEntryIssuer::API, $this->agent->getToken(), DLogEntry::FATAL, $logMessage);
             DServerLog::log(DServerLog::FATAL, $logMessage);
 


### PR DESCRIPTION
Added logging for skipped hashes, so that an administrator can spot the hashes that have been cracked but skipped. This can happen for example when Hashcat rebuilds the hash incorrectly