### PR TITLE
Added three new indexes for mysql to improve speed

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,9 @@
+# v0.14.4 -> vx.x.x
+
+## Enhancements
+
+- Added three more indexes in MySQL to improve the task view drastically (Note: these are not created on update due to performance issues, only on new installs)
+
 # v0.14.3 -> v0.14.4
 
 ## Enhancements

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -1031,6 +1031,7 @@ ALTER TABLE `Assignment`
 ALTER TABLE `Chunk`
   ADD PRIMARY KEY (`chunkId`),
   ADD KEY `taskId` (`taskId`),
+  ADD KEY `progress` (`progress`),
   ADD KEY `agentId` (`agentId`);
 
 ALTER TABLE `Config`
@@ -1142,6 +1143,8 @@ ALTER TABLE `TaskDebugOutput`
 ALTER TABLE `TaskWrapper`
   ADD PRIMARY KEY (`taskWrapperId`),
   ADD KEY `hashlistId` (`hashlistId`),
+  ADD KEY `priority` (`priority`),
+  ADD KEY `isArchived` (`isArchived`),
   ADD KEY `accessGroupId` (`accessGroupId`);
 
 ALTER TABLE `User`


### PR DESCRIPTION
These three indexes improve the loading time of the tasks page and agent progress updates significantly (>5 seconds down to <1 second) when having more than just a few tasks/chunks.

NOTE: These indexes are created on new installations only. They are not created automatically in updates, as this can be a very heavy operation on the database. Therefore, this is something, users will have to run manually under controlled circumstances (e.g. ideally not much load on the server, etc.).

Following MySQL queries would add the same three indexes as in a new installation:

```mysql
CREATE INDEX idx_isArchived ON TaskWrapper(isArchived);
CREATE INDEX idx_priority   ON TaskWrapper(priority);
CREATE INDEX idx_progress   ON Chunk(progress);
```