### PR TITLE
Additional index to improve performance for agents getting tasks

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - Added three more indexes in MySQL to improve the task view drastically (Note: these are not created on update due to performance issues, only on new installs)
+- Added an additional multi-column index in MySQL on the chunk table to increase performance for agents getting tasks (Note: these are not created on update due to performance issues, only on new installs)
 
 # v0.14.3 -> v0.14.4
 

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -1032,7 +1032,8 @@ ALTER TABLE `Chunk`
   ADD PRIMARY KEY (`chunkId`),
   ADD KEY `taskId` (`taskId`),
   ADD KEY `progress` (`progress`),
-  ADD KEY `agentId` (`agentId`);
+  ADD KEY `agentId` (`agentId`),
+  ADD KEY `idx_task_progress_length` (`taskId`, `progress`, `length`);
 
 ALTER TABLE `Config`
   ADD PRIMARY KEY (`configId`),


### PR DESCRIPTION
When agents check which task they should work on, the server often does this query:

```
SELECT SUM(length) AS sum FROM Chunk WHERE taskId=<taskId> AND progress>=10000;
```

This PR adds the index over (taskId, progress, length) making this query dropping from >1 seconds to 0.1 seconds when having tasks with larger numbers of chunks.

Use following MySQL command to build the query on an existing system (may need multiple minutes):
```
CREATE INDEX idx_task_progress_length ON Chunk(taskId, progress, length); 
```