### PR TITLE
Fixed patch to global permission group

### DIFF
--- a/ci/apiv2/test_globalpermissiongroup.py
+++ b/ci/apiv2/test_globalpermissiongroup.py
@@ -15,11 +15,16 @@ class GlobalPermissionGroupTest(BaseTest):
     def test_patch(self):
         model_obj = self.create_test_object()
 
-        attr = 'permRightGroupCreate'
-        model_obj.permissions[attr] = True
+        # with how the current testing framework, works, multiple permissions have to be set, otherwise conflicting
+        # permissions, will be set to false by default
+        attributes = ["permUserDelete", "permUserRead", "permUserUpdate", "permUserCreate", "permRightGroupCreate",
+                      "permRightGroupDelete", "permRightGroupRead", "permRightGroupUpdate"]
+        for attr in attributes:
+            model_obj.permissions[attr] = True
         model_obj.save()
 
         # Request object from backend and validate PATCHed permission
+        attr = 'permRightGroupCreate'
         obj = self.model_class.objects.get(pk=model_obj.id)
         self.assertTrue(obj.permissions[attr])
 

--- a/src/inc/apiv2/model/globalpermissiongroups.routes.php
+++ b/src/inc/apiv2/model/globalpermissiongroups.routes.php
@@ -102,21 +102,16 @@ class GlobalPermissionGroupAPI extends AbstractModelAPI {
           }
         }
       }
-      
-      // Get enabled 'old-style' permissions
+
       $legacyPerms = [];
       foreach($permissions as $crudPerm => $value) {
-        if ($value === true) {
-          $legacyPerms = array_merge($legacyPerms, $c2o[$crudPerm]);
+        if (array_key_exists($crudPerm, $c2o)) {
+          $filled_perms = array_fill_keys($c2o[$crudPerm], $value);
+          $legacyPerms = array_merge($legacyPerms, $filled_perms);
         }
       }
-      
-      // Modify data to conform with updateGroupPermssions input
-      $permData = [];
-      foreach($legacyPerms as $key) {
-        array_push($permData, $key . "-1");
-      }
-      AccessControlUtils::updateGroupPermissions($id, $permData);
+
+      AccessControlUtils::addToPermissions($id, $legacyPerms);
     }
 }
 

--- a/src/inc/utils/AccessControlUtils.class.php
+++ b/src/inc/utils/AccessControlUtils.class.php
@@ -30,7 +30,6 @@ class AccessControlUtils {
       throw new HTException("Administrator group cannot be changed!");
     }
     $current_permissions_decoded = json_decode($current_permissions, true);
-    error_log("testest: " . $current_permissions_decoded);
 
     $merged_permissions = array_merge($current_permissions_decoded, $perm);
     Factory::getRightGroupFactory()->set($group, RightGroup::PERMISSIONS, json_encode($merged_permissions));

--- a/src/inc/utils/AccessControlUtils.class.php
+++ b/src/inc/utils/AccessControlUtils.class.php
@@ -23,6 +23,19 @@ class AccessControlUtils {
     return Factory::getRightGroupFactory()->filter([]);
   }
   
+  public static function addToPermissions($groupId, $perm) {
+    $group = AccessControlUtils::getGroup($groupId);
+    $current_permissions = $group->getPermissions();
+    if ($current_permissions == 'ALL') {
+      throw new HTException("Administrator group cannot be changed!");
+    }
+    $current_permissions_decoded = json_decode($current_permissions, true);
+    error_log("testest: " . $current_permissions_decoded);
+
+    $merged_permissions = array_merge($current_permissions_decoded, $perm);
+    Factory::getRightGroupFactory()->set($group, RightGroup::PERMISSIONS, json_encode($merged_permissions));
+  }
+
   /**
    * @param int $groupId
    * @param array $perm


### PR DESCRIPTION
Fixed bug in global permission group that where keys that were not included in the patch were removed from the permission group. Resolves #1255 