### PR TITLE
Fixed version ordering to reverse on task creation

### DIFF
--- a/src/tasks.php
+++ b/src/tasks.php
@@ -413,7 +413,7 @@ else if (isset($_GET['new'])) {
   $oF = new OrderFilter(CrackerBinary::CRACKER_BINARY_ID, "DESC");
   UI::add('binaries', Factory::getCrackerBinaryTypeFactory()->filter([]));
   $versions = Factory::getCrackerBinaryFactory()->filter([Factory::ORDER => $oF]);
-  usort($versions, ["Util", "versionComparisonBinary"]);
+  array_reverse(usort($versions, ["Util", "versionComparisonBinary"]));
   UI::add('versions', $versions);
   UI::add('pageTitle', "Create Task");
 }


### PR DESCRIPTION
With the change to semver/comparator, the behavior on the task creation page changed when it comes to the ordering of the cracker version sorting.
This fixes that again it is ordering it descending and the newest version is selected by default.