### PR TITLE
Fix DBA generator inconsistency and introduce workflow

### DIFF
--- a/.github/workflows/dba-generator.yml
+++ b/.github/workflows/dba-generator.yml
@@ -1,0 +1,36 @@
+name: DBA Generator
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+permissions:
+  contents: read
+
+jobs:
+  dba-generator:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Re-generate the DBA models
+        run: php src/dba/models/generator.php
+
+      - name: Confirm the committed DBA models match the generated ones
+        run: |
+          git diff --exit-code -- src/dba \
+            ':(exclude)src/dba/models/generator.php' \
+            ':(exclude)src/dba/models/*.template.txt' \
+            || (echo "::error file=src/dba/models/generator.php::The generated DBA models are out of date. Run 'php src/dba/models/generator.php' and commit the result." && exit 1)

--- a/src/dba/models/generator.php
+++ b/src/dba/models/generator.php
@@ -534,7 +534,7 @@ $CONF['Task'] = [
     ['name' => 'chunkSize', 'read_only' => True, 'type' => 'int64'],
     ['name' => 'forcePipe', 'read_only' => True, 'type' => 'bool'],
     ['name' => 'usePreprocessor', 'read_only' => True, 'type' => 'int', 'alias' => 'preprocessorId'],
-    ['name' => 'preprocessorCommand', 'read_only' => True, 'type' => 'str(256)'],
+    ['name' => 'preprocessorCommand', 'read_only' => False, 'type' => 'str(256)'],
   ],
 ];
 $CONF['TaskDebugOutput'] = [


### PR DESCRIPTION
There was a DBA generator inconsistency where the model file was updated directly and not via generator. This is fixed in this PR.

To avoid this in the future, a new github workflow is added which checks that the generator.php produces exactly what is committed.